### PR TITLE
If maxAge = 75, top age group should be 70-74, not 75-79

### DIFF
--- a/R/AGESEX.R
+++ b/R/AGESEX.R
@@ -30,25 +30,23 @@
 #' 		1691000,1409000,1241000,887000,697000,525000,348000,366000)
 #' Age     <- seq(0, 75, by = 5)
 #' 
-#' # final age group assumed closed
-#' ageRatioScore(Males, Age, ageMax = 75) 
-#' # if it's open, remove it by dropping ageMax
-#' ageRatioScore(Males, Age, ageMax = 70)    # 3.9, matches PAS
-#' ageRatioScore(Females, Age, ageMax = 70)  # 3.65 matches PAS
-#' ageRatioScore(Females, Age, ageMax = 70, method = "Ramachandran") # 1.8
-#' ageRatioScore(Females, Age, ageMax = 70, method = "Zelnick")      # 2.4
+#' # Top age group should not include ageMax
+#' ageRatioScore(Males, Age, ageMax = 75)    # 3.9, matches PAS
+#' ageRatioScore(Females, Age, ageMax = 75)  # 3.66 matches PAS
+#' ageRatioScore(Females, Age, ageMax = 75, method = "Ramachandran") # 1.8
+#' ageRatioScore(Females, Age, ageMax = 75, method = "Zelnick")      # 2.4
 ageRatioScore <- function(Value, Age, ageMin = 0, ageMax = max(Age), method = "UN"){
 	stopifnot(length(Value) == length(Age))
 	method          <- tolower(method)
 	stopifnot(method %in% c("un","zelnick","ramachandran"))
 
 	# cut down data if necessary
-	keep            <- Age >= ageMin & Age <= ageMax
+	keep            <- Age >= ageMin & Age < ageMax
 	Value           <- Value[keep]
 	Age             <- Age[keep]
 	
 	# selectors for numerators and denominators
-	numi            <- Age > ageMin & Age < ageMax
+	numi            <- Age > ageMin & Age < max(Age)
 	denomleft       <- shift.vector(numi, -1) 
 	denommiddle     <- numi
 	denomright      <- shift.vector(numi, 1)
@@ -104,7 +102,7 @@ ageRatioScore <- function(Value, Age, ageMin = 0, ageMax = max(Age), method = "U
 sexRatioScore <- function(Males, Females, Age, ageMin = 0, ageMax = max(Age)){
 	stopifnot(length(Males) == length(Age) & length(Males) == length(Females))
 	
-	keep      <- Age >= ageMin & Age <= ageMax
+	keep      <- Age >= ageMin & Age < ageMax
 	Males     <- Males[keep]
 	Females   <- Females[keep]
 	


### PR DESCRIPTION
Hi Tim, I'm a colleague of Greg Freedman-Ellis at IPUMS. As Greg mentioned in an email to you, he and I recently wrote some code to compute some of the indices you include in your package. One that we did compute was the UN age-sex accuracy index, so I thought I'd take a look at the code for that function.

One thing I noticed was that a couple of the documentation examples, for `ageSexAccuracy()` and `sexRatioScore()`, weren't returning the values noted. Specifically, `sexRatioScore(Males, Females, Age)` was returning 2.6 instead of 2.2, and `ageSexAccuracy(Males, Females, Age)` was returning 17.9 instead of 14.3.

It seems these discrepancies stemmed from the treatment of the `ageMax` argument in `ageRatioScore()` and `sexRatioScore()`. By including age groups less than *or equal* to `ageMax`, these functions were including the age group with the lower bound of `ageMax`. For instance, if `ageMax` was set to 70, the functions would include the group from the example data labeled 70, which consists of 70-74 year olds.

I made a few small changes, and all of the examples for these functions should now return the values listed. Let me know if you have any questions about my suggested revisions, and thanks for your work on this package! As Greg, said, I wish we would have discovered the package before our recent project!