### PR TITLE
Fix warning message not displayed nicely in R console.

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: DemoTools
 Type: Package
 Title: Standardize, Evaluate, and Adjust Demographic Data
-Version: 0.5.944
+Version: 0.5.945
 Date: 2018-07-20
 Author: Tim Riffe, Sean Fennell, Juan Galeano, Jose Manuel Aburto
 Maintainer: Tim Riffe <tim.riffe@gmail.com>

--- a/R/splitMono.R
+++ b/R/splitMono.R
@@ -160,9 +160,9 @@ monoCloseout <- function(popmat, pops, pivotAge = 90, splitfun = sprague, OAG = 
 	if (!(max(Age1) - 10) >= pivotAge){
 		pivotAge <- max(Age1) - 10
 		if (pivotAge < 80){
-			warning("pivotAge wasn't in rownames(popmat), moved it to 3rd 
-							from bottom row of popmat, but appears to be < 80
-							so returning sprague() output as-is, no extra closeout performed.")
+			warning("pivotAge wasn't in rownames(popmat), moved it to 3rd ", 
+			        "from bottom row of popmat, but appears to be < 80 ",
+			        "so returning sprague() output as-is, no extra closeout performed.")
 			return(pops)
 		}
 		warning("pivotAge moved to ", pivotAge, ", continued.")


### PR DESCRIPTION
Fix warning message not displayed nicely in R console.
I encountered the warning in `monoCloseout` function when called from `sprague`.

When we have a long warning or error or message to print that looks somehow like this:
`warning("phrase1... phrase2... phrase3...")` and needs to be printed on multiple lines, I would suggest writing it like this

`warning("phrase1...",` 
`"phrase2...",` 
`"phrase3...")` 

or like this `warning("phrase1\n phrase2\n phrase3\n ...")`.  But in this case the phrase have to be short enough.

NOT like this (note missing commas)
`warning("phrase1...` 
`phrase2...` 
`phrase3...")`
Otherwise, depending on how user's console is setup, screen resolution etc the message can appear weird looking.

Marius
