### PR TITLE
ageMin ageMax

### DIFF
--- a/R/AGEHEAP.R
+++ b/R/AGEHEAP.R
@@ -81,7 +81,7 @@ Whipple <- function(Value, Age, ageMin = 25, ageMax = 65, digit = c(0,5)){
 #' @param ageMax integer. The upper age bound used for calculations. Default 89.
 
 #' @details \code{ageMax} is an inclusive upper bound, treated as interval. If you want ages
-#' 20 to 89, then give \code{ageMin = 20} and \code{ageMax = 89}. \code{ageMax} may be
+#' 20 to 89, then give \code{ageMin = 20} and \code{ageMax = 89}, not 90. \code{ageMax} may be
 #' internally rounded down if necessary so that \code{ageMax - ageMin + 1} is evenly divisible by 10.
 #' @return The value of the index. 
 #' @references 
@@ -264,7 +264,8 @@ Bachi <- function(Value, Age, ageMin = 30, ageMax = 79, pasex = FALSE){
 
 
 #' @details \code{digit} could also be a vector of digits, but the more digits one includes (excepting 0 and 5) the closer the index will get to 1. 
-#' It is therefore recommended for single digits, or else \code{c(0,5)}. \code{ageMax} is an inclusive upper bound, treated as interval.
+#' It is therefore recommended for single digits, or else \code{c(0,5)}. 
+#' \code{ageMax} is an inclusive upper bound, treated as interval.
 #'  If you want ages 20 to 89, then give \code{ageMin = 20} and \code{ageMax = 89}, not 90. By default all available ages greater than or equal to \code{ageMin} are used. 
 #' 
 #' @return The value of the index.

--- a/R/AGESEX.R
+++ b/R/AGESEX.R
@@ -160,8 +160,8 @@ sexRatioScore <- function(Males, Females, Age, ageMin = 0, ageMax = max(Age), OA
 
 #' @details Age groups must be of equal intervals. Five year age groups are assumed.
 #' If the final element of \code{Males} and \code{Females} is the open age group,
-#' then either make sure \code{ageMax} is lower than it, or leave \code{OAG} as \code{TRUE} so that it is properly removed for calculations. The method argument 
-#' is passed to \code{ageRatioScore()}, where it determines weightings of numerators and denominators, 
+#' then either make sure \code{ageMax} is lower than it, or leave \code{OAG} as \code{TRUE} so that it is properly removed for calculations. 
+#' The method argument is passed to \code{ageRatioScore()}, where it determines weightings of numerators and denominators, 
 #' except in the case of Das Gupta, where it's a different method entirely (see \code{ageSexAccuracyDasGupta()}.
 
 #' @return The value of the index.

--- a/R/LIFIT.R
+++ b/R/LIFIT.R
@@ -20,8 +20,11 @@
 #' @param ageMin integer. Optional lower age bound for calculations.
 #' @param ageMax integer. Optional upper age bound for calculations.
 #' @export
-#' @details \code{lx1} and \code{lx2} can be of different lengths and grouped differently. For example, either or both input vectors could be in single or five-year age groups
+#' @details \code{lx1} and \code{lx2} can be of different lengths and grouped differently. 
+#' For example, either or both input vectors could be in single or five-year age groups
 #' for this function. Results are selected internally for 5-year age groups, and vector lengths are matched.
+#' \code{ageMax} is an inclusive upper bound, treated as interval.
+#'  If you want the age-group 70-74 to be included in calculations, then give \code{ageMax = 70}, not 75.
 #' The input vectors can also be of different lifetable radices. As with the original Fortran code, 
 #' the open age group must be included in input vectors, even though it is not included in calcs. 
 #' If your final age group is not open, then tack an extra element to it to simulate an open element,
@@ -91,7 +94,7 @@ ADM <- function(
 			    N = 5, 
 			    consecutive = TRUE, 
 			    ageMin = ageMin, 
-			    ageMax = ageMax - 1)
+			    ageMax = ageMax)
 	# trim lx to needed ages
 	lx1_5  <- lx1[Age1 %in% age5]
 	lx2_5  <- lx2[Age2 %in% age5]
@@ -124,6 +127,7 @@ ADM <- function(
 #' @details \code{lx1} and \code{lx2} can be of different lengths and grouped differently. 
 #' For example, either or both input vectors could be in single or five-year age groups
 #' for this function. Results are selected internally for 5-year age groups, and vector lengths are matched.
+#' If you want the age-group 70-74 to be included in calculations, then give \code{ageMax = 70}, not 75.
 #' The input vectors can also be of different lifetable radices. As with the original Fortran code, 
 #' the open age group must be included in input vectors, even though it is not included in calcs. 
 #' If your final age group is not open, then tack an extra element to it to simulate an open element,

--- a/man/ADM.Rd
+++ b/man/ADM.Rd
@@ -29,8 +29,11 @@ ratios with optional age trimming.
 Based on LIFIT program from the MPCDA code base.
 }
 \details{
-\code{lx1} and \code{lx2} can be of different lengths and grouped differently. For example, either or both input vectors could be in single or five-year age groups
+\code{lx1} and \code{lx2} can be of different lengths and grouped differently. 
+For example, either or both input vectors could be in single or five-year age groups
 for this function. Results are selected internally for 5-year age groups, and vector lengths are matched.
+\code{ageMax} is an inclusive upper bound, treated as interval.
+ If you want the age-group 70-74 to be included in calculations, then give \code{ageMax = 70}, not 75.
 The input vectors can also be of different lifetable radices. As with the original Fortran code, 
 the open age group must be included in input vectors, even though it is not included in calcs. 
 If your final age group is not open, then tack an extra element to it to simulate an open element,

--- a/man/CoaleLi.Rd
+++ b/man/CoaleLi.Rd
@@ -32,7 +32,8 @@ It is probably better suited to rates than counts, but that is not a hard rule.
 }
 \details{
 \code{digit} could also be a vector of digits, but the more digits one includes (excepting 0 and 5) the closer the index will get to 1. 
-It is therefore recommended for single digits, or else \code{c(0,5)}. \code{ageMax} is an inclusive upper bound, treated as interval.
+It is therefore recommended for single digits, or else \code{c(0,5)}. 
+\code{ageMax} is an inclusive upper bound, treated as interval.
  If you want ages 20 to 89, then give \code{ageMin = 20} and \code{ageMax = 89}, not 90. By default all available ages greater than or equal to \code{ageMin} are used.
 }
 \examples{

--- a/man/Myers.Rd
+++ b/man/Myers.Rd
@@ -25,7 +25,7 @@ as a blended index. It is based on the principle that in the absence of age heap
 }
 \details{
 \code{ageMax} is an inclusive upper bound, treated as interval. If you want ages
-20 to 89, then give \code{ageMin = 20} and \code{ageMax = 89}. \code{ageMax} may be
+20 to 89, then give \code{ageMin = 20} and \code{ageMax = 89}, not 90. \code{ageMax} may be
 internally rounded down if necessary so that \code{ageMax - ageMin + 1} is evenly divisible by 10.
 }
 \examples{

--- a/man/RDM.Rd
+++ b/man/RDM.Rd
@@ -33,6 +33,7 @@ Based on LIFIT program from the MPCDA code base.
 \code{lx1} and \code{lx2} can be of different lengths and grouped differently. 
 For example, either or both input vectors could be in single or five-year age groups
 for this function. Results are selected internally for 5-year age groups, and vector lengths are matched.
+If you want the age-group 70-74 to be included in calculations, then give \code{ageMax = 70}, not 75.
 The input vectors can also be of different lifetable radices. As with the original Fortran code, 
 the open age group must be included in input vectors, even though it is not included in calcs. 
 If your final age group is not open, then tack an extra element to it to simulate an open element,

--- a/man/ageSexAccuracy.Rd
+++ b/man/ageSexAccuracy.Rd
@@ -35,8 +35,8 @@ a wrapper to \code{ageRatioScore()} and \code{sexRatioScore()}.
 \details{
 Age groups must be of equal intervals. Five year age groups are assumed.
 If the final element of \code{Males} and \code{Females} is the open age group,
-then either make sure \code{ageMax} is lower than it, or leave \code{OAG} as \code{TRUE} so that it is properly removed for calculations. The method argument 
-is passed to \code{ageRatioScore()}, where it determines weightings of numerators and denominators, 
+then either make sure \code{ageMax} is lower than it, or leave \code{OAG} as \code{TRUE} so that it is properly removed for calculations. 
+The method argument is passed to \code{ageRatioScore()}, where it determines weightings of numerators and denominators, 
 except in the case of Das Gupta, where it's a different method entirely (see \code{ageSexAccuracyDasGupta()}.
 }
 \examples{


### PR DESCRIPTION
## 310718
#File AGESEX.R
# In this file ageRatioScore,sexRatioScore,ageSexAccuracy,ageSexAccuracyDasGupta
# use the ageMax argument, but in most methods 5-year agegroups are needed in the
# input. So ageMax is set as default as max(Age), so no need to change this to
# being inclusive. I think.

##File LIFIT.R
#Change description and just changed ADM to be inclusive. Function RDM was
#already inclusive. Made description consistent explaining that if the user
#wants to include the age=group 70-74 as ageMax then specify ageMax = 70, not 75

##File utilsAge.R
# Funcion AGEN uses already ageMax as ibnclusive
# AGEN(Age1, Age2, N = 5, ageMax = 70)
# [1]  0  5 10 15 20 25 30 35 40 45 50 55 60 65 70

#R CMD check results
#0 errors | 0 warnings | 0 notes