### PR TITLE
update graduation vignette

### DIFF
--- a/vignettes/graduation_with_demotools.Rmd
+++ b/vignettes/graduation_with_demotools.Rmd
@@ -28,18 +28,17 @@ knitr::opts_chunk$set(
 ## How to use `DemoTools` to graduate counts in grouped ages
 
 ### What is graduation?
-Graduation is a practice used to derive figures for _n_-year age groups, for example 5-year age groups from census data, that are corrected for net reporting error [@siegel2004methods]. Essentially, these methods fit different curves to the original  _n_-year and redistribute them into single-year values. These techniques are designed so that the sum of the interpolated single-year values is consistent with the total for the groups as a whole. Among the major graduation methods are the Sprague [@sprague1880explanation] and Beers [@beers1945modified] oscilatory methods, monotone spline and the uniform distributions. More recently, the enalized composite link model (pclm) was proposed to ungroup coarsely aggregated data [@rizzi2015efficient]. All of these are implemented in `DemoTools`.
+Graduation is a practice used to derive figures for _n_-year age groups, for example 5-year age groups from census data, that are corrected for net reporting error [@siegel2004methods]. The basic idea is to fit different curves to the original  _n_-year and redistribute them into single-year values. These techniques are designed so that the sum of the interpolated single-year values is consistent with the total for the groups as a whole. Among the major graduation methods are the Sprague [@sprague1880explanation] and Beers [@beers1945modified] oscilatory methods, monotone spline and the uniform distribution. More recently, the penalized composite link model (pclm) was proposed to ungroup coarsely aggregated data [@rizzi2015efficient]. All of these methodologies are implemented in `DemoTools`.
 
 ### Why graduate?
 One of the main purposes of graduation is to refine the detail of available data in published statistics or surveys. This allows to estimate numbers of persons in single years of age from data originally in 5-year age groups. In practice, graduation of mortality curves has been very important to estimate reliable life tables, but also in fertility studies graduation is useful for the analysis of data from populations where demographic records are defective [@brass1960graduation].
 
 ### How is this different from smoothing?
-The main difference between graduation and smoothing is that graduation redistributes the counts or events into single-year age groups with the constrain that they sum to the total.The selection of the method to be used depends mostly on the balance between smoothness and closeness of fit to the data. Therefore, the analyst must decide which weight should be given to these two opposing considerations. 
+The main difference between graduation and smoothing is that graduation redistributes the counts or events into single-year age groups with the constrain that they sum to the original total. The selection of the method to be used depends mostly on the balance between smoothness and closeness of fit to the data. Therefore, the analyst must decide which weight should be given to these two opposing considerations. 
 
 ## Read in data
 ```{r,out.width='\\textwidth', fig.width= 6, fig.height=6, fig.align='center'}
 library(DemoTools)
-
 # 'pop1m_ind' available as package data
 Value <- pop5_mat[,4]
 Age   <- as.integer(rownames(pop5_mat))
@@ -50,12 +49,10 @@ plot(Age, Value, type = 'p',
      main = 'Original 5-year age-group population')
 ```
 
-## Graduation basic usage
-
 ## Methods choices
 
 ### Sprague
-@sprague1880explanation suggested the fifth-difference method based on one equation that depends on two polynomials of fourth degree forced to have a common ordinate, tangent and radius of curvature at $Y_{n+2}$ and at $Y_{n+3}$:
+@sprague1880explanation suggested the fifth-difference method based on one equation that depends on two polynomials of degree four forced to have a common ordinate, tangent and radius of curvature at $Y_{n+2}$ and at $Y_{n+3}$:
 
 \begin{equation*}
 y_{n+2+x} = \frac{(x+2)}{1!}\Delta y_n +
@@ -65,7 +62,7 @@ y_{n+2+x} = \frac{(x+2)}{1!}\Delta y_n +
 \frac{x^3(x-1)(5x-7)}{4!}\Delta y^5_n 
 \end{equation*}
 
-There are six observations $Y_{n},Y_{n+1},Y_{n+2},Y_{n+3},Y_{n+4}$ and $Y_{n+5}$ involved in the leading differences, $\Delta y_{n},\dots,\Delta^5 y_n $. The interpolated points fall on curves that pass through the given points, and the interpolated subdivisions add up to the data in the original groups. To implement this method in `DemoTools` we use the function `graduate` with the option for method specified as `sprague`. 
+There are six observations $Y_{n},Y_{n+1},Y_{n+2},Y_{n+3},Y_{n+4}$ and $Y_{n+5}$ involved in the leading differences, $\Delta y_{n},\dots,\Delta^5 y_n $. The interpolated points fall on curves that pass through the given points, and the interpolated subdivisions add up to the data in the original groups. To implement this method in `DemoTools`, use the function `graduate` with the option for method specified as `sprague`. 
 
 
 ```{r,out.width='\\textwidth', fig.width= 6, fig.height=6, fig.align='center'}
@@ -95,7 +92,8 @@ plot(single.age, beers.ordinary, type = 'l',
      xlab = 'Age',
      main = 'Graduation with Beers methods')
 lines(single.age,beers.modified, col = "red")
-legend("topright",lty=1,col=c(1,2),legend=c("ordinary (5-yr constrained)","modified (smoother)"))
+legend("topright",lty=1,col=c(1,2),legend=c("ordinary (5-yr constrained)",
+                                            "modified (smoother)"))
 #check the totals
 sum(beers.ordinary)
 sum(beers.modified)
@@ -103,7 +101,7 @@ sum(Value)
 ```
 
 ### Monotone spline
-Graduation by a monotone spline is another option available in `DemoTools`. This option offers an algorithm to produce interpolants that preserve properties such as monotonicity or convexity that are present in the data [@fritsch1980monotone]. These are desirable conditions to not introduce biased details or artifacts that cannot be ascertained from the data [@hyman1983accurate]. To run this algorithm in `DemoTools` the option `mono` should be selected as follows.
+Graduation by a monotone spline is another option available in `DemoTools`. This option offers an algorithm to produce interpolants that preserve properties such as monotonicity or convexity that are present in the data [@fritsch1980monotone]. These are desirable conditions to not introduce biased details that cannot be ascertained from the data [@hyman1983accurate]. To run this algorithm in `DemoTools` the option `mono` should be selected as follows:
 
 ```{r,out.width='\\textwidth', fig.width= 6, fig.height=6, fig.align='center'}
 mono.grad <- graduate(Value, Age, method = "mono")
@@ -138,7 +136,7 @@ sum(Value)
 
 
 ### Uniform
-With the `uniform` option graduation is performed assuming that the counts are uniformly distributed across each age interval. It is also assumed that the initial age intervals are integers rgeater than or equal to one. This option simplu splits aggregate counts in age-groups into single age groups.
+With the `uniform` option graduation is performed assuming that the counts are uniformly distributed across each age interval. It is also assumed that the initial age intervals are integers greater than or equal to one. This option simply splits aggregate counts in age-groups into single age groups.
 
 ```{r,out.width='\\textwidth', fig.width= 6, fig.height=6, fig.align='center'}
 unif.grad <- graduate(Value, Age, method = "unif")
@@ -175,7 +173,8 @@ legend("topright",
        lty=1,
        col=c('black','red','blue','green','pink','magenta'),
        legend=c("Beers ordinary",
-                "Beers modified",'Sprague','Monotone','PCLM','Uniform'))
+                "Beers modified",'Sprague','Monotone','PCLM',
+                'Uniform'))
 #check the totals
 sum(beers.ordinary)
 sum(beers.modified)
@@ -186,10 +185,32 @@ sum(Value)
 ### Using a standard
 The function `rescaleAgeGroups` rescales a vector of counts in some given age-groups to approximate the counts into different age grouping. This method is appealing when, for example, the user wants to rescale single ages to sum to 5-year age groups. It is particularly useful in processes of making consistent different datasets to provide the same structure of data prior to construction of a lifetable for example.
 
-## Graduation as a light smoother
-light heaping can be grouped and then graduated, holding counts constrained.
+To do: TR: rescaleAgeGroups() I'm, not sure. How about you get DemoData death or pop counts from an HMD country and in single ages from Jorge. Then rescale them to match HMD counts in 5-year age groups? Just an idea.
 
-## Graduation as a lifetable step
-We could do abridged tables, which have their own consequential a(x) assumptions, or we could graduate to single ages and make a simpler lifetables. In this case the a(x) assumption is partly outsourced to the graduation and partly simplified by assuming midpoints (usually).
+```{r,out.width='\\textwidth', fig.width= 6, fig.height=6, fig.align='center'}
+AgeIntRandom <- c(1L, 5L, 2L, 2L, 4L, 4L, 1L, 2L, 3L, 4L, 3L, 3L, 3L, 3L, 5L)
+AgeInt5      <- rep(5, 9)
+original     <- runif(45, min = 0, max = 100)
+pop1         <- groupAges(original, 0:45, AgeN = int2ageN(AgeIntRandom, FALSE))
+pop2         <- groupAges(original, 0:45, AgeN = int2ageN(AgeInt5, FALSE))
+# inflate (in this case) pop2
+perturb      <- runif(length(pop2), min = 1.05, max = 1.2)
+
+pop2         <- pop2 * perturb
+
+# a recursively constrained solution
+pop1resc <- rescaleAgeGroups(Value1 = pop1, 
+					AgeInt1 = AgeIntRandom,
+					Value2 = pop2, 
+					AgeInt2 = AgeInt5, 
+					splitfun = splitUniform, 
+                 recursive = TRUE)
+pop1resc
+
+```
+
+## Graduation as a light smoother
+The graduation family functions `graduate` work strictly with data in 5-year age groups. Therefore, graduation can be seen as a light smoother when dealing with counts that are not grouped in 5-year age groups. In order to graduate counts that are not in 5-year age groups, an additional step to do this is necessary prior to graduation. For example, if counts are reported in single age groups, then before graduating the user needs to groups them in 5-year age groups, which can be interpreted as a constrained smooth. Compared with the `agesmth` family of functions, in this case there would not be transfers between 5-year age groups.
+
 
 ## References


### PR DESCRIPTION
Still to do: a real example with rescaleAgeGroups

TR: rescaleAgeGroups() I'm, not sure. How about you get DemoData death or pop counts from an HMD country and in single ages from Jorge. Then rescale them to match HMD counts in 5-year age groups? Just an idea.

Do you mean the same country or different countries from both sources?

I moved the Graduation as a lifetable step section to the lifetable vignette for now. It seems to me that this step is too specialized and for only a set of demographers highly specialized in ax's . I am not sure whether the best is to include it in a vignette or if it would create confusion among a standard user. Maybe a separate vignette for this specific case would be best. Let me know what you think, 
jm