### PR TITLE
Sx computation for single age life tables

### DIFF
--- a/R/lt_id.R
+++ b/R/lt_id.R
@@ -350,17 +350,20 @@ lt_id_Ll_S      <- function(nLx, lx, AgeInt, N = c(5, 1)) {
     # middle age groups
     mind          <- 3:(n - 2)
     Sx[mind]      <- nLx[mind + 1] / nLx[mind]
+    # penultimate age group
+    Sx[n - 1]       <- nLx[n] / (nLx[n - 1] + nLx[n])
+    # closeout
+    Sx[n]           <- 0.0
   }
   if (N == 1) {
     LLXX          <- c(lx[1], nLx)
-    mind          <- 1:(n - 2)
+    mind          <- 1:(n - 1)
     Sx[mind]      <- LLXX[mind + 1] / LLXX[mind]
+    # closeout
+    Sx[n]           <- nLx[n] / (nLx[n - 1] + nLx[n])
   }
   
-  # penultimate age group
-  Sx[n - 1]       <- nLx[n] / (nLx[n - 1] + nLx[n])
-  # closeout
-  Sx[n]           <- 0.0
+  
   
   Sx
 }

--- a/R/lt_single.R
+++ b/R/lt_single.R
@@ -120,14 +120,15 @@ lt_single_mx <- function(nMx,
   Tx            <- Tx[ind]
   ex            <- ex[ind]
   
-  Sx            <- lt_id_Ll_S(nLx, lx, AgeInt = AgeInt, N = 1)
-  
   # some closeout considerations
   N             <- length(qx)
   qx[N]         <- 1
   nLx[N]        <- Tx[N]
   nAx[N]        <- ex[N]
   AgeInt[N]     <- NA
+  
+  # Survival ratios computed only after  nLx is closed out
+  Sx            <- lt_id_Ll_S(nLx, lx, AgeInt = AgeInt, N = 1)
   
   if (OAG) {
     if (OAnew == OA) {


### PR DESCRIPTION
Hi Tim! Please consider these changes to how survival ratios are computed for last age groups when life table is by single year of age. For abridged life tables, the first two age groups are collapsed into one Sx value for the five-year period and Sx for terminal age group is set to zero.  But for complete life tables there is no collapse for first age groups and thus there should be a non-zero Sx value for each age. Also, Sx should be computed only after the life table nLx is closed out in order to ensure the correct Sx value for the terminal age group.  Thanks! Sara