### PR TITLE
Checking name of function called works with namespaces

### DIFF
--- a/R/check_heaping.R
+++ b/R/check_heaping.R
@@ -24,7 +24,7 @@
 #' @examples
 #'  Age <- 0:99
 #' # 2.34,replicates SINGAGE males
-#'  (w05 <- check_heaping_whipple(pop1m_pasex, Age, 25, 60, digit = c(0,5))) 
+#'  (w05 <- check_heaping_whipple(pop1m_pasex, Age, 25, 60, digit = c(0,5)))
 #'
 #'  # implements formula from Roger et al. (1981, p. 148)
 #'  (w0 <- check_heaping_whipple(pop1m_pasex, Age, 25, 60, digit = 0))
@@ -38,15 +38,16 @@ check_heaping_whipple <-
            ageMin = 25,
            ageMax = 65,
            digit = c(0, 5)) {
-    
-    if (as.character(match.call()[[1]]) == "Whipple") {
+
+    fn_call <- deparse(match.call()[[1]])
+      if (identical(length(fn_call), 1L) && grepl("Whipple$", fn_call)) {
       warning("please use check_heaping_whipple() instead of Whipple().", call. = FALSE)
     }
-    
+
     stopifnot(length(digit) == 1 ||
                 (all(c(0, 5) %in% digit) & length(digit == 2)))
     stopifnot(length(Value) == length(Age))
-    
+
     numeratorind   <- Age >= ageMin & Age <= ageMax & Age %% 10 %in% digit
     numa           <- range(Age[numeratorind])
     # if we are checking just one digit, go down 7 up two, so that the right nr
@@ -55,13 +56,13 @@ check_heaping_whipple <-
     denominatorind <-
       Age >= (numa[1] - ifelse(length(digit) == 2, 2, 7)) &
       Age <= (numa[2] + 2)
-    
+
     # move check here- don't care about non-single ages outside this group
     stopifnot(is_single(Age[denominatorind]))
-    
-    whip           <- ifelse(length(digit) == 2, 5, 10) * 
+
+    whip           <- ifelse(length(digit) == 2, 5, 10) *
                          sum(Value[numeratorind]) / sum(Value[denominatorind])
-    
+
     return(whip)
   }
 #' @export
@@ -95,43 +96,44 @@ check_heaping_myers <- function(Value,
                   Age,
                   ageMin = 10,
                   ageMax = 89) {
-  if (as.character(match.call()[[1]]) == "Myers") {
+  fn_call <- deparse(match.call()[[1]])
+      if (identical(length(fn_call), 1L) && grepl("Myers$", fn_call)) {
     warning("please use check_heaping_myers() instead of Myers().", call. = FALSE)
   }
-  
+
   # hard code period to 10 for digits
   period  <- 10
-  
+
   # must be of same length for indexing
   stopifnot(length(Value) == length(Age))
   #stopifnot(ageMin %% period == 0 & ageMax %% period == 0)
-  
+
   # ageMax dynamically rounded down
   # to a total span divisible by period
   Diff    <- ageMax - ageMin + 1
   AgeMax  <- ageMin + Diff - Diff %% period
-  
+
   # may as well be certain here
   stopifnot(ageMax <= max(Age))
-  
+
   ind     <- Age >= ageMin & Age < AgeMax
-  
+
   stopifnot(is_single(Age[Age >= ageMin & Age <= AgeMax]))
   stopifnot(sum(ind) %% period == 0)
   # select out ages, place into matrix for summing over digits
   # a row corresponds to a digit
   VA      <- matrix(Value[ind], nrow = period, dimnames = list(0:(period - 1), NULL))
-  
+
   # sum staggered, once without the youngest group but with the oldest one (tab2)
   # and once with the youngest and without the oldest
-  tab1    <- rowSums(VA[,-ncol(VA), drop = FALSE]) 
+  tab1    <- rowSums(VA[,-ncol(VA), drop = FALSE])
   # differs from other implementations, but matches PASEX
-  
+
   tab2    <- rowSums(VA[,-1, drop = FALSE])
-  
+
   # weighted tabulation
   TAB     <- tab1 * 1:period + tab2 * c(period:1 - 1)
-  
+
   # interpret as % that would need to be redistributed...
   my      <- sum(abs(TAB / sum(TAB) - 1 / period)) * 50
   return(my)
@@ -158,9 +160,9 @@ Myers <- check_heaping_myers
 #' @examples
 #' Age <- 0:99
 #' # reproduces PASEX SINGAGE
-#' check_heaping_bachi(pop1m_pasex, Age, ageMin = 20, ageMax = 79, pasex = TRUE) 
+#' check_heaping_bachi(pop1m_pasex, Age, ageMin = 20, ageMax = 79, pasex = TRUE)
 #' # default simpler
-#' check_heaping_bachi(pop1m_pasex, Age, ageMin = 20, ageMax = 79) 
+#' check_heaping_bachi(pop1m_pasex, Age, ageMin = 20, ageMax = 79)
 
 check_heaping_bachi <-
   function(Value,
@@ -168,16 +170,17 @@ check_heaping_bachi <-
            ageMin = 30,
            ageMax = 79,
            pasex = FALSE) {
-    if (as.character(match.call()[[1]]) == "Bachi") {
+    fn_call <- deparse(match.call()[[1]])
+      if (identical(length(fn_call), 1L) && grepl("Bachi$", fn_call)) {
       warning("please use check_heaping_bachi() instead of Bachi().", call. = FALSE)
     }
-    
+
     stopifnot(length(Age) == length(Value))
     stopifnot(is_single(Age[Age >= (ageMin - 5) & Age <= ageMax]))
     # make a matrix for numerators
     w1           <- matrix(0, nrow = length(Age), ncol = 10)
     w2           <- matrix(0, nrow = length(Age), ncol = 10)
-    
+
     if (pasex) {
       w1[Age %in% seq(30, 70, 10), 1]  <- 1
       w1[Age %in% seq(31, 71, 10), 2]  <- 1
@@ -194,7 +197,7 @@ check_heaping_bachi <-
       w1[Age %in% c(27, 77), 8]        <- .5
       w1[Age %in% seq(28, 68, 10), 9]  <- 1
       w1[Age %in% seq(29, 69, 10), 10] <- 1
-      
+
       # more quirky ranges
       w2[Age > 25 & Age < 75, 1]       <- 1
       w2[Age %in% c(25, 75), 1]        <- .5
@@ -218,28 +221,28 @@ check_heaping_bachi <-
       w2[Age %in% c(24, 74), 10]       <- .5
     } else {
       # cheap way to make upper bound inclusive
-      
+
       Diff                                              <- ageMax - ageMin + 1
       AgeMax                                            <- ageMin + Diff - Diff %% 10
       if (AgeMax > max(Age)) {
         AgeMax                                          <- AgeMax - 10
       }
-      
+
       markers                                           <- row(w1) - col(w1)
       w1[markers %% 10 == 0 &
            markers >= ageMin & markers < AgeMax]        <- 1
       w2[markers == ageMin - 5 | markers == AgeMax - 5] <- .5
       w2[markers > ageMin - 5 & markers < AgeMax - 5]   <- 1
     }
-    
+
     numerators                                          <- colSums(Value * w1)
     denominators                                        <- colSums(Value * w2)
-    
+
     ratio                                               <- 100 * numerators / denominators
-    
+
     ratioeq                                             <- ratio - (sum(w2) / sum(w1))
-    
-    
+
+
     sum(abs(ratioeq))  / 2
   }
 
@@ -287,28 +290,29 @@ check_heaping_coale_li <-
            ageMax = max(Age),
            terms = 5,
            digit = 0) {
-    if (as.character(match.call()[[1]]) == "CoaleLi") {
+    fn_call <- deparse(match.call()[[1]])
+      if (identical(length(fn_call), 1L) && grepl("CoaleLi$", fn_call)) {
       warning("please use check_heaping_coale_li() instead of CoaleLi().", call. = FALSE)
     }
-    
+
     stopifnot(length(Age) == length(Value))
     reference <- ma(ma(Value, n = terms), n = terms)
-    
+
     ratio     <- Value / reference
-    
+
     # deprecated: make sure tested age range is divisible by 10..
     #	agerange  <- maxAge - minAge
     #	agerange  <- 10 * floor(agerange / 10)
     #	# adjust maxage if necessary
     #	maxAge    <- minAge + agerange
-    
+
     ind       <- Age >= ageMin & Age <= ageMax
     stopifnot(is_single(Age[ind]))
     stopifnot(sum(ind) >= 10)
-    
+
     ages      <- max(c(min(Age), ageMin)):min(c(ageMax, max(Age)))
     avgRatios <- tapply(ratio[ind], ages %% 10, mean, na.rm = TRUE)
-    
+
     # return avg deviation for specified digit(s)
     mean(avgRatios[as.character(digit)])
   }
@@ -350,21 +354,22 @@ check_heaping_noumbissi <-
            ageMin = 20,
            ageMax = 64,
            digit = 0) {
-    if (as.character(match.call()[[1]]) == "Noumbissi") {
+    fn_call <- deparse(match.call()[[1]])
+      if (identical(length(fn_call), 1L) && grepl("Noumbissi$", fn_call)) {
       warning("please use check_heaping_noumbissi() instead of Noumbissi().", call. = FALSE)
     }
-    
+
     stopifnot(is_single(Age[Age >= (ageMin - 2) & Age <= (ageMax + 2)]))
     stopifnot(length(Age) == length(Value))
     stopifnot(length(digit) == 1)
-    
+
     numi   <- Age >= ageMin & Age <= ageMax & Age %% 10 %in% digit
     denomi <- shift.vector(numi, -2) |
       shift.vector(numi, -1) |
       numi |
       shift.vector(numi, 1) |
       shift.vector(numi, 2)
-    
+
     5 * sum(Value[numi]) / sum(Value[denomi])
   }
 
@@ -391,10 +396,11 @@ check_heaping_spoorenberg <- function(Value,
                         Age,
                         ageMin = 20,
                         ageMax = 64) {
-  if (as.character(match.call()[[1]]) == "Spoorenberg") {
+  fn_call <- deparse(match.call()[[1]])
+      if (identical(length(fn_call), 1L) && grepl("Spoorenberg$", fn_call)) {
     warning("please use check_heaping_spoorenberg() instead of Spoorenberg().", call. = FALSE)
   }
-  
+
   stopifnot(length(Age) == length(Value))
   stopifnot(is_single(Age[Age >= (ageMin - 2) & Age <= (ageMax + 2)]))
   digits <- 0:9
@@ -443,13 +449,14 @@ check_heaping_kannisto <- function(Value,
                          Age,
                          Agei = 90,
                          pow = "exp") {
-  if (as.character(match.call()[[1]]) == "KannistoHeap") {
+  fn_call <- deparse(match.call()[[1]])
+      if (identical(length(fn_call), 1L) && grepl("KannistoHeap$", fn_call)) {
     warning("please use check_heaping_kannisto() instead of KannistoHeap().", call. = FALSE)
   }
   stopifnot(length(Agei) == 1)
   stopifnot(is_single(Age[Age >= (Agei - 2) & Age <= (Agei + 2)]))
   denomi   <- Age %in% ((Agei - 2):(Agei + 2))
-  
+
   if (any(Value[denomi] == 0)) {
     pow    <- 1000
   }
@@ -514,14 +521,15 @@ KannistoHeap <- check_heaping_kannisto
 #'check_heaping_jdanov(Value, Age, Agei = c(95,100,105))
 
 check_heaping_jdanov <- function(Value, Age, Agei = seq(95, 105, by = 5)) {
-  if (as.character(match.call()[[1]]) == "Jdanov") {
+  fn_call <- deparse(match.call()[[1]])
+      if (identical(length(fn_call), 1L) && grepl("Jdanov$", fn_call)) {
     warning("please use check_heaping_jdanov() instead of Jdanov().", call. = FALSE)
   }
-  
+
   stopifnot(is_single(Age[Age >= (min(Agei) - 2) &
                             Age <= (max(Agei) + 2)]))
   numi   <- Age %in% Agei
-  
+
   # this way of doing the denom makes it possible to
   # have duplicate values in the denom, for the case that
   # the numerator ages are closer together than 5. Innocuous otherwise
@@ -530,9 +538,9 @@ check_heaping_jdanov <- function(Value, Age, Agei = seq(95, 105, by = 5)) {
     sum(Value[numi]) +
     sum(Value[shift.vector(numi, 1)]) +
     sum(Value[shift.vector(numi, 2)])
-  
+
   500 * sum(Value[numi]) / denom
-  
+
 }
 #' @export
 #' @rdname check_heaping_jdanov
@@ -585,12 +593,12 @@ heapify <- function(Value,
   fivepdf <- rescale_vector(pdf5) * p5
   #x7,x8,x9,x0,x1,x2,x3
   tenpdf  <- rescale_vector(pdf0) * p0
-  
+
   # center ages:
-  
+
   A10 <- Age[Age %% 10 == 0 & Age >= ageMin & Age <= ageMax]
   A5  <- Age[Age %% 5 == 0 & !Age %in% A10 & Age >= ageMin & Age <= ageMax]
-  
+
   # rest could happen in a matrix, but this might be clearer to read:
   ai <- sort(c(A5, A10))
   for (a in ai) {
@@ -611,9 +619,9 @@ heapify <- function(Value,
 
 
 #' Detect if heaping is worse on terminal digits 0s than on 5s
-#' 
+#'
 #' @description Ages ending in 0 often have higher apparent heaping than ages ending in 5. In this case, data in 5-year age bins might show a sawtooth pattern. If heaping ocurrs in roughly the same amount on 0s and 5s, then it may be sufficient to group data into 5-year age groups and then graduate back to single ages. However, if heaping is worse on 0s, then this procedure tends to produce a wavy pattern in count data, with 10-year periodicity. In this case it is recommended to use one of the methods of \code{smooth_age_5()} as an intermediate step before graduation.
-#' 
+#'
 #' @details Data is grouped to 5-year age bins. The ratio of each value to the average of its neighboring values is calculated. If 0s have stronger attraction than 5s then we expect these ratios to be >1 for 0s and <1 for 5s. Ratios are compared within each 10-year age group in the evaluated age range. If in the evaluated range there are at most two exceptions to this rule (0s>5s), then the ratio of the mean of these ratios is returned, and it is recommended to use a smoother method. Higher values suggest use of a more aggressive method. This approach is only slightly different from that of Feeney, as implemented in the \code{smooth_age_5_zigzag_inner()} functions. This is not a general measure of roughness, but rather an indicator of this particular pattern of age attraction.
 #' @export
 #' @inheritParams heapify
@@ -664,10 +672,11 @@ check_heaping_sawtooth <-
            Age,
            ageMin = 40,
            ageMax = max(Age[Age %% 5 == 0]) - 10) {
-    if (as.character(match.call()[[1]]) == "zero_pref_sawtooth") {
+    fn_call <- deparse(match.call()[[1]])
+      if (identical(length(fn_call), 1L) && grepl("zero_pref_sawtooth$", fn_call)) {
       warning("please use check_heaping_sawtooth() instead of zero_pref_sawtooth().", call. = FALSE)
     }
-    
+
     # rather than stopifnot() check, just make it work.
     ageMin   <- ageMin - ageMin %% 10
     # group to 5-year ages if not already.
@@ -683,7 +692,7 @@ check_heaping_sawtooth <-
     if (sum(ai) %% 2 != 0 | any(is.na(m05))) {
       m05    <- m05[,-ncol(m05)]
     }
-    
+
     # need rather consistent x0 > x5 pattern
     #if (sum(diff(sign(log(m05))) == -2) < (ncol(m05) - 2)){
     # i.e. it could be very rough still, but not necessarily
@@ -692,7 +701,7 @@ check_heaping_sawtooth <-
     # requires smoothing.
     #	return(FALSE)
     #}
-    
+
     # mean of 0s divided by mean of 5s, that simple.
     1 / ratx(rowMeans(m05, na.rm = TRUE))
   }
@@ -734,7 +743,7 @@ zero_pref_sawtooth <- check_heaping_sawtooth
 #'\dontrun{
 #'	#cols <- RColorBrewer::brewer.pal(7,"Reds")[3:7]
 #'  cols <-  c("#FC9272", "#FB6A4A", "#EF3B2C", "#CB181D", "#99000D")
-#'  
+#'
 #' 	plot(A5, groupAges(smoothed), type='l',xlim=c(20,80),ylim=c(0,3e5))
 #'	lines(A5, groupAges(h1),col=cols[1])
 #' 	lines(A5, groupAges(h2),col=cols[2])
@@ -755,10 +764,11 @@ check_heaping_roughness <-
            Age,
            ageMin = 20,
            ageMax = max(Age[Age %% 5 == 0])) {
-    if (as.character(match.call()[[1]]) == "five_year_roughness") {
+    fn_call <- deparse(match.call()[[1]])
+      if (identical(length(fn_call), 1L) && grepl("five_year_roughness$", fn_call)) {
       warning("please use check_heaping_roughness() instead of five_year_roughness().", call. = FALSE)
     }
-    
+
     # rather than stopifnot() check, just make it work.
     ageMin <- ageMin - ageMin %% 5
     # group to 5-year ages if not already.
@@ -766,13 +776,13 @@ check_heaping_roughness <-
     A5     <- names2age(VH5)
     # evalauated age range
     ai     <- A5 >= ageMin & A5 <= ageMax
-    
+
     d1     <- diff(VH5[ai])
     # compare with something smooth, loess by default.
     d1s    <- agesmth1(Value = d1,
                        Age = A5[ai][-1],
                        OAG = FALSE)
-    
+
     mean(abs(d1 - d1s) / abs(d1s))
   }
 #' @export

--- a/R/extra_mortality.R
+++ b/R/extra_mortality.R
@@ -154,10 +154,11 @@ lt_rule_m_extrapolate <- function(mx,
                                                  "LF4", "LF5", "LF6",
                                                  "poissonL", "binomialL"),
                                   ...) {
-  if (as.character(match.call()[[1]]) == "extra.mortality") {
-    warning("please use lt_rule_m_extrapolate() instead of extra_mortality().", call. = FALSE)
+    fn_call <- deparse(match.call()[[1]])
+    if (identical(length(fn_call), 1L) && grepl("extra.mortality$", fn_call)) {
+        warning("please use lt_rule_m_extrapolate() instead of extra_mortality().", call. = FALSE)
   }
-  
+
   # Save the input
   input <- as.list(environment())
 
@@ -170,23 +171,23 @@ lt_rule_m_extrapolate <- function(mx,
     opt.method = match.arg(opt.method),
     ...
   )
-  
+
   pv <- predict(object = M,
                 x = x_extr)
-  
+
   # which ages are not to be replaced with fitted values?
   L  <- !(x %in% x_extr)
-  
+
   # Create the output object
   if (is.vector(mx)) {
     names(mx)    <- x
     values       <- c(mx[L], pv)
-    
+
   } else {
     rownames(mx) <- x
     values       <- rbind(mx[L, ], pv)
   }
-  
+
   # Exit
   out <- list(
     input = input,
@@ -215,8 +216,8 @@ extra.mortality <- lt_rule_m_extrapolate
 #'   message("\nAges in fit  :", paste(range(x$input$x_fit), collapse = " - "))
 #'   message("\nAges in extrapolation:", paste(range(x$input$x_extr), collapse = " - "))
 #' }
-#' 
-#' 
+#'
+#'
 #' #' coef function for extra_mortality method
 #' #' @param object An object of the class \code{"extra_mortality"}.
 #' #' @inheritParams print.extra_mortality

--- a/R/graduate.R
+++ b/R/graduate.R
@@ -26,11 +26,12 @@ graduate_uniform <-
            Age,
            OAG = TRUE,
            OAvalue = 1) {
-    
-    if (as.character(match.call()[[1]]) == "splitUniform") {
+
+    fn_call <- deparse(match.call()[[1]])
+    if (identical(length(fn_call), 1L) && grepl("splitUniform$", fn_call)) {
       warning("please use graduate_uniform() instead of splitUniform().", call. = FALSE)
     }
-    
+
     if (missing(Age) & missing(AgeInt)) {
       Age      <- names2age(Value)
     }
@@ -47,7 +48,7 @@ graduate_uniform <-
     out
   }
 
-#' @export  
+#' @export
 #' @rdname graduate_uniform
 splitUniform <- graduate_uniform
 
@@ -89,7 +90,7 @@ splitUniform <- graduate_uniform
 #' \dontrun{
 #'   plot(seq(0,100,by=5), pop5_mat[,1]/5, type = 's')
 #'   lines(0:100,
-#'     p1, 
+#'     p1,
 #'     lty = 1,
 #'     col = "red")
 #'
@@ -98,42 +99,43 @@ splitUniform <- graduate_uniform
 graduate_sprague <- function(Value,
                              Age,
                              OAG = TRUE) {
-  
-  if (as.character(match.call()[[1]]) == "sprague") {
+
+  fn_call <- deparse(match.call()[[1]])
+  if (identical(length(fn_call), 1L) && grepl("sprague$", fn_call)) {
     warning("please use graduate_sprague() instead of sprague().", call. = FALSE)
   }
-  
+
   punif1       <- graduate_uniform(
-    Value = Value, 
-    Age = Age, 
+    Value = Value,
+    Age = Age,
     OAG = OAG)
   # this is innocuous if ages are already grouped
   a1           <- as.integer(names(punif1))
   pop5         <- groupAges(
-    punif1, 
+    punif1,
     Age = a1,
     N = 5,
     shiftdown = 0
   )
   # depending on OAG, highest age may shift down.
   a5           <- as.integer(names(pop5))
-  
+
   # generate coefficient matrix
   scm          <- graduate_sprague_expand(
-    Value = pop5, 
+    Value = pop5,
     Age = a5,
     OAG = OAG)
-  
+
   # redistribute
   pop1         <- scm %*% pop5
-  
+
   dim(pop1)    <- NULL
   # label and return
   names(pop1)  <- min(Age):(length(pop1) - 1)
-  
+
   # no sense adding closeout behavior here, when it isn't offered
   # in grabill or beers. Better make wrapper with this sugar.
-  
+
   #	# default closeout with monoCloseout().
   #	# set to FALSE to turn off, write "mono"
   #	if (is.logical(closeout)){
@@ -188,37 +190,37 @@ sprague <- graduate_sprague
 #' dim(coefsclosed)
 
 graduate_sprague_expand    <- function(
-  Value, 
-  Age, 
+  Value,
+  Age,
   OAG = TRUE) {
   popmat                         <- as.matrix(Value)
-  
+
   # figure out ages and years
   Age5                           <- Age
   Age1                           <- min(Age5):max(Age5)
-  
+
   # nr 5-year age groups
   m                              <- length(Value)
   # nr rows in coef mat.
   n                              <- m * 5 - ifelse(OAG, 4, 0)
   # number of middle blocks
   MP                             <- m - ifelse(OAG, 5, 4)
-  
+
   # get the split coefficients
   # block for ages 0-9
   g1g2                           <- matrix(
-    c( 0.3616, -0.2768, 0.1488, -0.0336, 
-       0.0000, 0.2640, -0.0960, 0.0400, 
-       -0.0080, 0.0000, 0.1840, 0.0400, 
-       -0.0320, 0.0080, 0.0000, 0.1200, 
-       0.1360, -0.0720, 0.0160, 0.0000, 
-       0.0704, 0.1968, -0.0848, 0.0176, 
-       0.0000, 0.0336, 0.2272, -0.0752, 
-       0.0144, 0.0000, 0.0080, 0.2320, 
-       -0.0480, 0.0080, 0.0000,-0.0080, 
+    c( 0.3616, -0.2768, 0.1488, -0.0336,
+       0.0000, 0.2640, -0.0960, 0.0400,
+       -0.0080, 0.0000, 0.1840, 0.0400,
+       -0.0320, 0.0080, 0.0000, 0.1200,
+       0.1360, -0.0720, 0.0160, 0.0000,
+       0.0704, 0.1968, -0.0848, 0.0176,
+       0.0000, 0.0336, 0.2272, -0.0752,
+       0.0144, 0.0000, 0.0080, 0.2320,
+       -0.0480, 0.0080, 0.0000,-0.0080,
        0.2160, -0.0080, 0.0000, 0.0000,
-       -0.0160, 0.1840, 0.0400, -0.0080, 
-       0.0000,-0.0176, 0.1408, 0.0912, 
+       -0.0160, 0.1840, 0.0400, -0.0080,
+       0.0000,-0.0176, 0.1408, 0.0912,
        -0.0144, 0.0000
     ),
     nrow = 10,
@@ -226,14 +228,14 @@ graduate_sprague_expand    <- function(
     byrow = TRUE
   )
   # block for middle ages
-  
-  
+
+
   g3                             <- matrix(
-    c( -0.0128, 0.0848, 0.1504, -0.0240, 
-       0.0016,-0.0016, 0.0144, 0.2224, 
-       -0.0416, 0.0064, 0.0064, -0.0336, 
-       0.2544, -0.0336, 0.0064, 0.0064, 
-       -0.0416, 0.2224, 0.0144, -0.0016, 
+    c( -0.0128, 0.0848, 0.1504, -0.0240,
+       0.0016,-0.0016, 0.0144, 0.2224,
+       -0.0416, 0.0064, 0.0064, -0.0336,
+       0.2544, -0.0336, 0.0064, 0.0064,
+       -0.0416, 0.2224, 0.0144, -0.0016,
        0.0016, -0.0240, 0.1504, 0.0848,
        -0.0128
     ),
@@ -241,7 +243,7 @@ graduate_sprague_expand    <- function(
     5,
     byrow = TRUE
   )
-  
+
   # block prior to closeout
   g4g5                           <- matrix(
     c(0.0000,-0.0144,0.0912,0.1408,
@@ -262,12 +264,12 @@ graduate_sprague_expand    <- function(
     ncol = 5,
     byrow = TRUE
   )
-  
+
   ## create a Sprague coefficient matrix for 5-year age groups
   bm                             <- matrix(0, nrow = n, ncol =  m)
   ## insert upper left block
   bm[1:10, 1:5]                  <- g1g2
-  
+
   # determine positions of middle blocks
   rowpos                         <-
     matrix(11:((MP * 5) + 10), ncol = 5, byrow = TRUE)
@@ -276,20 +278,20 @@ graduate_sprague_expand    <- function(
     # calculate the slices and add middle panels accordingly
     bm[rowpos[i,], colpos[i,]]   <- g3
   }
-  
+
   ## insert last two panels
-  
+
   fr                             <- nrow(bm) - ifelse(OAG, 10, 9)
   lr                             <- fr + 9
   fc                             <- ncol(bm) - ifelse(OAG, 5, 4)
   lc                             <- fc + 4
   bm[fr:lr, fc:lc]               <- g4g5
-  
+
   if (OAG) {
     # preserve open ended age group
     bm[nrow(bm), ncol(bm)]       <- 1
   }
-  
+
   bm
 }
 
@@ -318,22 +320,22 @@ graduate_grabill_expand <- function(Value, Age, OAG = TRUE) {
   # figure out ages and years
   Age5   <- Age
   Age1   <- min(Age5):max(Age5)
-  
+
   # nr 5-year age groups
   m      <- length(Value)
   # nr rows in coef mat.
   n      <- m * 5 - ifelse(OAG, 4, 0)
   # number of middle blocks
   MP     <- m - ifelse(OAG, 5, 4)
-  
+
   # primary grabill coef block
   g3g    <- matrix(
-    c( 0.0111, 0.0816, 0.0826, 0.0256, 
-       -0.0009, 0.0049, 0.0673, 0.0903, 
-       0.0377, -0.0002, 0.0015, 0.0519, 
-       0.0932, 0.0519, 0.0015,-0.0002, 
+    c( 0.0111, 0.0816, 0.0826, 0.0256,
+       -0.0009, 0.0049, 0.0673, 0.0903,
+       0.0377, -0.0002, 0.0015, 0.0519,
+       0.0932, 0.0519, 0.0015,-0.0002,
        0.0377, 0.0903, 0.0673, 0.0049,
-       -0.0009, 0.0256, 0.0826, 0.0816, 
+       -0.0009, 0.0256, 0.0826, 0.0816,
        0.0111
     ),
     5,
@@ -342,12 +344,12 @@ graduate_grabill_expand <- function(Value, Age, OAG = TRUE) {
   )
   ## create a Grabill coefficient matrix for 5-year age groups
   gm                <- matrix(0, nrow = n, ncol =  m)
-  
+
   fr                <- nrow(gm) - ifelse(OAG, 10, 9)
   lr                <- fr + 9
   fc                <- ncol(gm) - ifelse(OAG, 5, 4)
   lc                <- fc + 4
-  
+
   # ----------------------------------------------------------
   # Note: for the boundary ages we keep shuffling in g3g, the same grabill
   # coefs. The columns on the boundaries will NOT sum to 1. These coefs are
@@ -362,11 +364,11 @@ graduate_grabill_expand <- function(Value, Age, OAG = TRUE) {
   g4g5g              <- matrix(0, nrow = 10, ncol = 5)
   g4g5g[1:5, 2:5]    <- g3g[, 1:4]
   g4g5g[6:10, 3:5]   <- g3g[, 1:3]
-  
+
   gm[1:10, 1:5]      <- g1g2g
   gm[fr:lr, fc:lc]   <- g4g5g
-  
-  
+
+
   # determine positions of middle blocks
   rowpos             <- matrix(11:((MP * 5) + 10), ncol = 5, byrow = TRUE)
   colpos             <- row(rowpos) + col(rowpos) - 1
@@ -374,12 +376,12 @@ graduate_grabill_expand <- function(Value, Age, OAG = TRUE) {
     # calculate the slices and add middle panels accordingly
     gm[rowpos[i, ], colpos[i,]] <- g3g
   }
-  
+
   if (OAG) {
     # preserve open ended age group
     gm[nrow(gm), ncol(gm)]    <- 1
   }
-  
+
   # return coefficient matrix
   gm
 }
@@ -426,19 +428,20 @@ graduate_grabill <- function(
   Value,
   Age,
   OAG = TRUE) {
-  
-  if (as.character(match.call()[[1]]) == "grabill") {
+
+  fn_call <- deparse(match.call()[[1]])
+  if (identical(length(fn_call), 1L) && grepl("grabill$", fn_call)) {
     warning("please use graduate_grabill() instead of grabill().", call. = FALSE)
   }
-  
+
   punif1       <- graduate_uniform(
-    Value = Value, 
-    Age = Age, 
+    Value = Value,
+    Age = Age,
     OAG = OAG)
   # this is innocuous if ages are already grouped
   a1           <- as.integer(names(punif1))
   pop5         <- groupAges(
-    punif1, 
+    punif1,
     Age = a1,
     N = 5,
     shiftdown = 0
@@ -449,16 +452,16 @@ graduate_grabill <- function(
   #                   pop5,
   #                   Age = a5,
   #                   OAG = OAG)
-  
-  
+
+
   # get coefficient matrices for Sprague and Grabill
   scmg              <- graduate_grabill_expand(pop5, Age = a5, OAG = OAG)
   scm               <- graduate_sprague_expand(pop5, Age = a5, OAG = OAG)
-  
+
   # split pop counts
   pops              <- scm %*% pop5
   popg              <- scmg %*% pop5
-  
+
   # ---------------------------------------------
   # now we graft the two estimates together,
   # preserving the middle part for grabill, and blending
@@ -467,16 +470,16 @@ graduate_grabill <- function(
   m                 <- nrow(pops)
   lr                <- m - 1
   fr                <- lr - 9
-  
+
   # these weights do much better than linear weights.
   w10               <- exp(row(pops[1:10, , drop = FALSE])) / exp(10.1)
-  
+
   # blend together young ages
   popg[1:10,]       <- w10 * popg[1:10,] + (1 - w10) * pops[1:10,]
-  
+
   # blend together old ages
   popg[fr:lr,]      <- w10[10:1,] * popg[fr:lr,] + (1 - w10[10:1,]) * pops[fr:lr,]
-  
+
   # ---------------------------------------------
   # now we take care of the marginal constraint problem
   # make weighting matrix
@@ -484,12 +487,12 @@ graduate_grabill <- function(
   wr[1:10,]         <- w10
   wr[fr:lr,]        <- w10[10:1,]
   wr[nrow(wr),]     <- 0
-  
+
   # weighted marginal sums. The difference we need to redistribute
   redist            <- colSums(pops) - colSums(popg)
-  
+
   middle.part       <- popg * wr
-  
+
   # the difference to redistribute
   add.in            <- t(t(prop.table(middle.part, 2)) * redist)
   popg              <- popg + add.in
@@ -497,10 +500,10 @@ graduate_grabill <- function(
   # label dims and return
   AgeOut            <- min(Age):(min(Age) + nrow(popg) - 1)
   dim(popg)         <- NULL
-  # TR: this is necessary if final age group is open, 
+  # TR: this is necessary if final age group is open,
   # but not in an age evenly divisible by 5
   names(popg)       <- min(Age):(length(popg) - 1)
-  
+
   popg
 }
 
@@ -556,63 +559,63 @@ graduate_beers_expand <- function(Value,
                                   method = "Mod") {
   method <- tolower(method)
   stopifnot(method %in% c("mod", "ord"))
-  
+
   # nr 5-year age groups
   m      <- length(Value)
   # nr rows in coef mat.
   n      <- m * 5 - ifelse(OAG, 4, 0)
   # number of middle blocks
   MP     <- m - ifelse(OAG, 5, 4)
-  
+
   if (method == "mod") {
     ## Beers Modified Split
     g1g2 <- matrix(
-      c( 0.3332, -0.1938, 0.0702, -0.0118, 
-         0.0022 , 0.2569, -0.0753, 0.0205, 
-         -0.0027, 0.0006 , 0.1903, 0.0216, 
-         -0.0146, 0.0032, -0.0005 , 0.1334, 
-         0.0969, -0.0351, 0.0059, -0.0011 , 
+      c( 0.3332, -0.1938, 0.0702, -0.0118,
+         0.0022 , 0.2569, -0.0753, 0.0205,
+         -0.0027, 0.0006 , 0.1903, 0.0216,
+         -0.0146, 0.0032, -0.0005 , 0.1334,
+         0.0969, -0.0351, 0.0059, -0.0011 ,
          0.0862, 0.1506, -0.0410, 0.0054,
-         -0.0012 , 0.0486, 0.1831, -0.0329, 
-         0.0021, -0.0009 , 0.0203, 0.1955, 
-         -0.0123, -0.0031, -0.0004 , 0.0008, 
+         -0.0012 , 0.0486, 0.1831, -0.0329,
+         0.0021, -0.0009 , 0.0203, 0.1955,
+         -0.0123, -0.0031, -0.0004 , 0.0008,
          0.1893, 0.0193, -0.0097, 0.0003 ,
-         -0.0108, 0.1677, 0.0577, -0.0153, 
-         0.0007 ,-0.0159, 0.1354, 0.0972, 
+         -0.0108, 0.1677, 0.0577, -0.0153,
+         0.0007 ,-0.0159, 0.1354, 0.0972,
          -0.0170, 0.0003
       ),
       nrow = 10,
       ncol = 5,
       byrow = TRUE
     )
-    
+
     g3 <- matrix(
-      c( -0.0160, 0.0973, 0.1321, -0.0121, 
-         -0.0013 ,-0.0129, 0.0590, 0.1564, 
-         0.0018, -0.0043 ,-0.0085, 0.0260, 
-         0.1650, 0.0260, -0.0085 ,-0.0043, 
+      c( -0.0160, 0.0973, 0.1321, -0.0121,
+         -0.0013 ,-0.0129, 0.0590, 0.1564,
+         0.0018, -0.0043 ,-0.0085, 0.0260,
+         0.1650, 0.0260, -0.0085 ,-0.0043,
          0.0018, 0.1564, 0.0590, -0.0129 ,
-         -0.0013, -0.0121, 0.1321, 0.0973, 
+         -0.0013, -0.0121, 0.1321, 0.0973,
          -0.0160
       ),
       5,
       5,
       byrow = TRUE
     )
-    
+
     g4g5 <- matrix(
-      c( 0.0003, -0.0170, 0.0972, 0.1354, 
-         -0.0159 , 0.0007, -0.0153, 0.0577, 
-         0.1677, -0.0108 , 0.0003, -0.0097, 
-         0.0193, 0.1893, 0.0008 ,-0.0004, 
+      c( 0.0003, -0.0170, 0.0972, 0.1354,
+         -0.0159 , 0.0007, -0.0153, 0.0577,
+         0.1677, -0.0108 , 0.0003, -0.0097,
+         0.0193, 0.1893, 0.0008 ,-0.0004,
          -0.0031, -0.0123, 0.1955, 0.0203 ,
-         -0.0009, 0.0021, -0.0329, 0.1831, 
-         0.0486 ,-0.0012, 0.0054, -0.0410, 
-         0.1506, 0.0862 ,-0.0011, 0.0059, 
-         -0.0351, 0.0969, 0.1334 ,-0.0005, 
-         0.0032, -0.0146, 0.0216, 0.1903 , 
-         0.0006, -0.0027, 0.0205, -0.0753, 
-         0.2569 , 0.0022, -0.0118, 0.0702, 
+         -0.0009, 0.0021, -0.0329, 0.1831,
+         0.0486 ,-0.0012, 0.0054, -0.0410,
+         0.1506, 0.0862 ,-0.0011, 0.0059,
+         -0.0351, 0.0969, 0.1334 ,-0.0005,
+         0.0032, -0.0146, 0.0216, 0.1903 ,
+         0.0006, -0.0027, 0.0205, -0.0753,
+         0.2569 , 0.0022, -0.0118, 0.0702,
          -0.1938, 0.3332
       ),
       nrow = 10,
@@ -623,50 +626,50 @@ graduate_beers_expand <- function(Value,
   if (method == "ord") {
     ## Beers Oscillatory (Johnson spreadsheet)
     g1g2 <- matrix(
-      c( 0.3333, -0.1636, -0.021, 0.0796, 
-         -0.0283, 0.2595, -0.078, 0.013, 
-         0.01, -0.0045, 0.1924, 0.0064, 
-         0.0184, -0.0256, 0.0084, 0.1329, 
-         0.0844, 0.0054, -0.0356, 0.0129, 
-         0.0819, 0.1508, -0.0158, -0.0284, 
-         0.0115, 0.0404, 0.2, -0.0344, 
-         -0.0128, 0.0068, 0.0093, 0.2268, 
-         -0.0402, 0.0028, 0.0013,-0.0108, 
+      c( 0.3333, -0.1636, -0.021, 0.0796,
+         -0.0283, 0.2595, -0.078, 0.013,
+         0.01, -0.0045, 0.1924, 0.0064,
+         0.0184, -0.0256, 0.0084, 0.1329,
+         0.0844, 0.0054, -0.0356, 0.0129,
+         0.0819, 0.1508, -0.0158, -0.0284,
+         0.0115, 0.0404, 0.2, -0.0344,
+         -0.0128, 0.0068, 0.0093, 0.2268,
+         -0.0402, 0.0028, 0.0013,-0.0108,
          0.2272, -0.0248, 0.0112, -0.0028,
-         -0.0198, 0.1992, 0.0172, 0.0072, 
-         -0.0038,-0.0191, 0.1468, 0.0822, 
+         -0.0198, 0.1992, 0.0172, 0.0072,
+         -0.0038,-0.0191, 0.1468, 0.0822,
          -0.0084, -0.0015),
       nrow = 10,
       ncol = 5,
       byrow = TRUE
     )
-    
+
     g3 <- matrix(
-      c( -0.0117, 0.0804, 0.157, -0.0284, 
-         0.0027,-0.002, 0.016, 0.22, 
-         -0.04, 0.006, 0.005, -0.028, 
-         0.246, -0.028, 0.005, 0.006, 
-         -0.04, 0.22, 0.016, -0.002, 
-         0.0027, -0.0284, 0.157, 0.0804, 
+      c( -0.0117, 0.0804, 0.157, -0.0284,
+         0.0027,-0.002, 0.016, 0.22,
+         -0.04, 0.006, 0.005, -0.028,
+         0.246, -0.028, 0.005, 0.006,
+         -0.04, 0.22, 0.016, -0.002,
+         0.0027, -0.0284, 0.157, 0.0804,
          -0.0117),
       5,
       5,
       byrow = TRUE
     )
-    
+
     g4g5 <- matrix(
-      c( -0.0015, -0.0084, 0.0822, 0.1468, 
-         -0.0191,-0.0038, 0.0072, 0.0172, 
-         0.1992, -0.0198,-0.0028, 0.0112, 
-         -0.0248, 0.2272, -0.0108, 0.0013, 
-         0.0028, -0.0402, 0.2268, 0.0093, 
-         0.0068, -0.0128, -0.0344, 0.2, 
-         0.0404, 0.0115, -0.0284, -0.0158, 
-         0.1508, 0.0819, 0.0129, -0.0356, 
-         0.0054, 0.0844, 0.1329, 0.0084, 
+      c( -0.0015, -0.0084, 0.0822, 0.1468,
+         -0.0191,-0.0038, 0.0072, 0.0172,
+         0.1992, -0.0198,-0.0028, 0.0112,
+         -0.0248, 0.2272, -0.0108, 0.0013,
+         0.0028, -0.0402, 0.2268, 0.0093,
+         0.0068, -0.0128, -0.0344, 0.2,
+         0.0404, 0.0115, -0.0284, -0.0158,
+         0.1508, 0.0819, 0.0129, -0.0356,
+         0.0054, 0.0844, 0.1329, 0.0084,
          -0.0256, 0.0184, 0.0064, 0.1924,
-         -0.0045, 0.01, 0.013, -0.078, 
-         0.2595,-0.0283, 0.0796, -0.021, 
+         -0.0045, 0.01, 0.013, -0.078,
+         0.2595,-0.0283, 0.0796, -0.021,
          -0.1636, 0.3333
       ),
       nrow = 10,
@@ -674,12 +677,12 @@ graduate_beers_expand <- function(Value,
       byrow = TRUE
     )
   }
-  
+
   ## create a Beers coefficient matrix for 5-year age groups
   bm               <- matrix(0, nrow = n, ncol =  m)
   ## insert upper left block
   bm[1:10, 1:5]    <- g1g2
-  
+
   # determine positions of middle blocks
   rowpos           <-
     matrix(11:((MP * 5) + 10), ncol = 5, byrow = TRUE)
@@ -689,21 +692,21 @@ graduate_beers_expand <- function(Value,
     bm[rowpos[i,], colpos[i,]] <- g3
   }
   ## standard format for Beers coefficients
-  
+
   ## insert last two panels
-  
+
   fr                <- nrow(bm) - ifelse(OAG, 10, 9)
   lr                <- fr + 9
   fc                <- ncol(bm) - ifelse(OAG, 5, 4)
   lc                <- fc + 4
   bm[fr:lr, fc:lc]   <- g4g5
-  
-  
+
+
   if (OAG) {
     # preserve open ended age group
     bm[nrow(bm), ncol(bm)]    <- 1
   }
-  
+
   bm
 }
 
@@ -779,24 +782,25 @@ graduate_beers <- function(Value,
                            OAG = TRUE,
                            method = "mod",
                            johnson = FALSE) {
-  if (as.character(match.call()[[1]]) == "beers") {
+  fn_call <- deparse(match.call()[[1]])
+  if (identical(length(fn_call), 1L) && grepl("beers$", fn_call)) {
     warning("please use graduate_beers() instead of beers().", call. = FALSE)
   }
-  
+
   if (missing(AgeInt)){
     AgeInt <- age2int(Age, OAG = OAG, OAvalue = 1)
   }
-  
+
   punif1       <- graduate_uniform(
-    Value = Value, 
+    Value = Value,
     AgeInt = AgeInt,
-    Age = Age, 
+    Age = Age,
     OAG = OAG)
-  
+
   # this is innocuous if ages are already grouped
   a1           <- as.integer(names(punif1))
   pop5         <- groupAges(
-    punif1, 
+    punif1,
     Age = a1,
     N = 5,
     shiftdown = 0)
@@ -806,10 +810,10 @@ graduate_beers <- function(Value,
   #                   pop5,
   #                   Age = a5,
   #                   OAG = OAG)
-  
+
   # generate coefficient matrix
   bm                <- graduate_beers_expand(pop5, OAG = OAG, method = method)
-  
+
   # redistribute
   pop1              <- bm %*% pop5
   dim(pop1)         <- NULL
@@ -821,7 +825,7 @@ graduate_beers <- function(Value,
                                    pop5 = pop5,
                                    pop1 = pop1)
   }
-  
+
   # TR will this fail if Age starts with 1?
   zero              <- min(Age)
   ages              <- zero:(nrow(bm) - 1 + zero)
@@ -848,7 +852,7 @@ beers <- graduate_beers
 #' @references
 #' \insertRef{stover2008spectrum}{DemoTools}
 graduate_beers_johnson <- function(Age0, pop5, pop1) {
-  
+
   # coefficient matrix
   DAPPSmod <- matrix(
     c(
@@ -919,7 +923,7 @@ graduate_pclm <- function(Value, Age, OAnew = max(Age), ...) {
     o5     <- length(Value) == lo
     stopifnot(o1 | o5)
   }
-  
+
   A        <- pclm(x = Age, y = Value, nlast = nlast, ...)
   B        <- A$fitted
   names(B) <- min(Age):OAnew
@@ -963,15 +967,16 @@ graduate_pclm <- function(Value, Age, OAnew = max(Age), ...) {
 #' 		}
 
 graduate_mono   <- function(
-  Value, 
-  AgeInt, 
-  Age, 
+  Value,
+  AgeInt,
+  Age,
   OAG = TRUE) {
-  
-  if (as.character(match.call()[[1]]) == "splitMono") {
+
+  fn_call <- deparse(match.call()[[1]])
+  if (identical(length(fn_call), 1L) && grepl("splitMono$", fn_call)) {
     warning("please use graduate_mono() instead of splitMono().", call. = FALSE)
   }
-  
+
   if (missing(Age) & missing(AgeInt)) {
     Age                 <- names2age(Value)
   }
@@ -982,12 +987,12 @@ graduate_mono   <- function(
   if (missing(Age)) {
     Age                 <- int2age(AgeInt)
   }
-  
+
   # if age is single return as-is
   if (is_single(Age)) {
     return(Value)
   }
-  
+
   # if last age Open, we preserve it
   if (OAG) {
     N                   <- length(Value)
@@ -998,20 +1003,20 @@ graduate_mono   <- function(
   }
   # if the final age is Open, then we should remove it and then
   # stick it back on
-  
+
   AgePred               <- c(min(Age), cumsum(AgeInt))
   y                     <- c(0, cumsum(Value))
   AgeS                  <- min(Age):sum(AgeInt)
   y1                    <- splinefun(y ~ AgePred, method = "monoH.FC")(AgeS)
   out                   <- diff(y1)
   names(out)            <- AgeS[-length(AgeS)]
-  
+
   # The open age group is maintained as-is.
   if (OAG) {
     out                 <- c(out, OAvalue)
     names(out)          <- AgeS
   }
-  
+
   out
 }
 
@@ -1076,11 +1081,12 @@ graduate_mono_closeout <-
            splitfun = graduate_sprague,
            OAG = TRUE,
            ...) {
-    if (as.character(match.call()[[1]]) == "monoCloseout") {
+    fn_call <- deparse(match.call()[[1]])
+    if (identical(length(fn_call), 1L) && grepl("monoCloseout$", fn_call)) {
       warning("please use graduate_mono_closeout() instead of monoCloseout().", call. = FALSE)
     }
     names(Value)        <- Age
-    
+
     if (missing(pops)) {
       pops              <- splitfun(Value, Age = Age, OAG = OAG, ...)
     }
@@ -1088,10 +1094,10 @@ graduate_mono_closeout <-
     AgeIn               <- Age
     # this does not smooth single ages, it only splits to single
     popmono             <- graduate_mono(Value, OAG = OAG, Age = AgeIn)
-    
+
     # some age pars
     Age                 <- as.integer(names(popmono))
-    
+
     # some checks on pivotAge...
     if (!(max(Age) - 10) >= pivotAge) {
       pivotAge          <- max(Age) - 10
@@ -1114,8 +1120,8 @@ graduate_mono_closeout <-
     if (ind){
       pop.c[1]       <- pops[p.i]
     }
-    
-    
+
+
     ## adjust back on initial pop 5x5 for age 90-94
     ## proportional distribution
     pop.c[is.na(pop.c)] <- 0
@@ -1128,14 +1134,14 @@ graduate_mono_closeout <-
     pop.c               <- c(pop.c, popmono[(p.i + 5):m])
     ## append Sprague interpolation before age 90
     pop.c               <- c(pops[1:(p.i - 1)], pop.c)
-    
+
     ## deal with negative values if applicable (but in principle should not be happening)
     pop.c[pop.c < 0]    <- 0
-    
+
     # label and return
     #dimnames(pop.c)    <- list(Age1, colnames(popmat))
     names(pop.c)     <- Age
-    
+
     pop.c
   }
 
@@ -1158,9 +1164,9 @@ monoCloseout <- graduate_mono_closeout
 #' This wrapper standardizes some inconsistencies in how open ages are dealt with. For example, with the \code{"pclm"} method, the last age group can be redistributed over a specified interval implied by increase \code{OAnew} beyond the range of \code{Age}. To get this same behavior from \code{"mono"}, or \code{"uniform"} specify \code{OAG = FALSE} along with an appropriately high \code{OAnew} (or integer final value of \code{AgeInt}.
 #'
 #' \code{OAnew} cannot be higher than \code{max(Age)+4} for \code{"sprague"} or \code{"beers"} methods. For \code{"uniform","mono","pclm"} it can be higher than this, and in each case the open age group is completely redistributed within this range, meaning it's not really open anymore.
-#' 
+#'
 #' For all methods, negative values are detected in output. If present, we deal with these in the following way: we take the geometric mean between the given output (with negative imputed with 0s) and the output of \code{graduate_mono()}, which is guaranteed non-negative. This only affects age groups where negatives were produced in the first pass. In our experience this only arises when using sprague, beers, or grabill methods, whereas all others are guarateed non-negative.
-#' 
+#'
 #' For any case where input data are in single ages, constraining results to sum to values in the original age groups will simply return the original input data, which is clearly not your intent. This might arise when using graduation as an implicit two-step smoother (group + graduate). In this case, separate the steps, first group using \code{groupAges()} then use \code{graduate(..., constrain = TRUE)}.
 #'
 #' @param Value numeric vector, presumably counts in grouped ages
@@ -1172,7 +1178,7 @@ monoCloseout <- graduate_mono_closeout
 #' @param keep0 logical. Default \code{FALSE}. If available, should the value in the infant age group be maintained, and ages 1-4 constrained?
 #' @param constrain logical. Default \code{FALSE}. Should output be constrained to sum within the input age groups?
 #' @param ... extra arguments passed to \code{graduate_beers()} or \code{graduate_pclm()}
-#' @seealso \code{\link{graduate_sprague}}, \code{\link{graduate_beers}}, \code{\link{graduate_uniform}}, \code{\link{graduate_mono}}, \code{\link{graduate_pclm}}, \code{\link{graduate_grabill}} 
+#' @seealso \code{\link{graduate_sprague}}, \code{\link{graduate_beers}}, \code{\link{graduate_uniform}}, \code{\link{graduate_mono}}, \code{\link{graduate_pclm}}, \code{\link{graduate_grabill}}
 #' @export
 #' @references
 #' \insertRef{pascariu2018ungroup}{DemoTools}
@@ -1265,7 +1271,7 @@ graduate <- function(Value,
   }
   # validate method choice
   method <- match.arg(method)
-  
+
   # TR: those methods that require AgeInt may depend on final value not being NA
   # even if it's an open age, in essence, keep all value inside this same "single"
   # age. NA coding isn't the best choice here, but we anticipate this and assign
@@ -1276,12 +1282,12 @@ graduate <- function(Value,
     nlast     <- OAnew - max(Age) + 1
     AgeInt[N] <- nlast
   }
-  
+
   # Sprague in strict 5-year age groups
   if (method == "sprague") {
     out <- graduate_sprague(Value, Age = Age, OAG = OAG)
   }
-  
+
   # Grabill in strict 5-year age groups
   if (method == "grabill") {
     out <- graduate_grabill(Value, Age = Age, OAG = OAG)
@@ -1303,7 +1309,7 @@ graduate <- function(Value,
                    ...)
     }
   }
-  
+
   # inconsistent ways of dealing with top age group.
   # if !OAG, then there is potential for inconsistency
   # between (min(Age) + sum(AgeInt)) and OAnew,
@@ -1313,8 +1319,8 @@ graduate <- function(Value,
   # TR: preference should go to AgeInt, because it refers
   # to data observations, whereas OAnew refers to a desired
   # change. So actually no change is needed?
-  
-  
+
+
   # Uniform respects irregular intervals
   if (method == "uniform") {
     OAvalue <- OAnew - max(Age) + 1
@@ -1327,7 +1333,7 @@ graduate <- function(Value,
     ) # OAvalue only if OAG and
     # extrapolation desired?
   }
-  
+
   # Mono respects irregular intervals
   if (method == "mono") {
     out <- graduate_mono(
@@ -1338,7 +1344,7 @@ graduate <- function(Value,
     ) # doesn't allow for extension?
     # actually it does IFF !OAG & !is.na(AgeInt[length(AgeInt)])
   }
-  
+
   # PCLM respects irregular intervals
   if (method == "pclm") {
     out <- graduate_pclm(Value = Value,
@@ -1346,7 +1352,7 @@ graduate <- function(Value,
                          OAnew = OAnew,
                          ...)
   }
-  
+
   # handle infant age for sprague and beers, if required.
   if (keep0) {
     if (Age[1] == 0 & AgeInt[1] == 1) {
@@ -1359,10 +1365,10 @@ graduate <- function(Value,
       out[1]   <- V0
     }
   }
-  
+
   n  <- length(out)
   a1 <- min(Age):(n - 1)
-  
+
   # detect negatives. Have default option to replace.
   # Favor quick over perfect, since this only can arise
   # in Sprague, Beers, or Grabill, which are quick. In this
@@ -1370,33 +1376,33 @@ graduate <- function(Value,
   # to sum to the same original value.
   ind0 <- out < 0
   if (any(ind0)){
-    # which 
+    # which
     agen         <- rep(Age, times = AgeInt)
     problem.ages <- agen[ind0]
     out[ind0]    <- 0
-    # well, this is maybe to complicated, can swap w 
+    # well, this is maybe to complicated, can swap w
     # different trick
     outm <- graduate_mono(
               Value = Value,
               Age = Age,
               AgeInt = AgeInt,
               OAG = OAG)
-    
+
     swap <- agen %in% problem.ages
-    
-    out.swap <- interp(cbind(out[swap],outm[swap]), 
-                       datesIn = c(10,20), 
-                       datesOut = 15, 
-                       method = "power", 
+
+    out.swap <- interp(cbind(out[swap],outm[swap]),
+                       datesIn = c(10,20),
+                       datesOut = 15,
+                       method = "power",
                        power = 1/2)
-    
+
     out[swap] <- out.swap
     dim(out)  <- NULL
   }
-  
+
   # option to contrain to sum to original age groups
   if (constrain){
-    out <- rescaleAgeGroups(Value1 = out, 
+    out <- rescaleAgeGroups(Value1 = out,
                             AgeInt1 = rep(1, n),
                             Value2 = Value,
                             AgeInt2 = AgeInt,
@@ -1404,9 +1410,9 @@ graduate <- function(Value,
                             recursive = FALSE)
     out[is.nan(out)] <- 0
   }
-  
+
   # last min names assure
   names(out) <- a1
-  
+
   out
 }

--- a/R/lt_id.R
+++ b/R/lt_id.R
@@ -17,7 +17,8 @@
 #' @return nMx vector of age specific death rates derived via identity.
 #' @export
 lt_id_qa_m <- function(nqx, nax, AgeInt) {
-  if (as.character(match.call()[[1]]) == "qxax2mx") {
+  fn_call <- deparse(match.call()[[1]])
+        if (identical(length(fn_call), 1L) && grepl("qxax2mx$", fn_call)) {
     warning("please use lt_id_qa_m() instead of qxax2mx().", call. = FALSE)
   }
   nqx / (AgeInt - (AgeInt - nax) * nqx)
@@ -42,7 +43,7 @@ qxax2mx <- lt_id_qa_m
 #'   if (as.character(match.call()[[1]]) == "mx2qx") {
 #'     warning("please use lt_id_m_q() instead of mx2qx().", call. = FALSE)
 #'   }
-#'   
+#'
 #'   qx <- (AgeInt * nMx) / (1 + (AgeInt - nax) * nMx)
 #'   ind <- qx > 1 | is.na(qx)
 #'   if (sum(ind) > 0) {
@@ -67,10 +68,11 @@ qxax2mx <- lt_id_qa_m
 #' @return nax numeric vector of average time spent in interval by those dying in interval via identity.
 #' @export
 lt_id_qm_a <- function(nqx, nMx, AgeInt) {
-  if (as.character(match.call()[[1]]) == "qxmx2ax") {
+  fn_call <- deparse(match.call()[[1]])
+        if (identical(length(fn_call), 1L) && grepl("qxmx2ax$", fn_call)) {
     warning("please use lt_id_qm_a() instead of qxmx2ax().", call. = FALSE)
   }
-  
+
   1 / nMx - AgeInt / nqx + AgeInt
 }
 
@@ -98,7 +100,7 @@ qxmx2ax <- lt_id_qm_a
 #   if (as.character(match.call()[[1]]) == "mxax2qx") {
 #     warning("please use lt_id_ma_q() instead of mxax2qx().", call. = FALSE)
 #   }
-#   
+#
 #   qx <- lt_id_m_q(nMx, nax, AgeInt)
 #   if (closeout) {
 #     qx[length(qx)] <- 1
@@ -108,7 +110,7 @@ qxmx2ax <- lt_id_qm_a
 #       )
 #     }
 #   }
-#   # no Age argument, so strong assumption that if 
+#   # no Age argument, so strong assumption that if
 #   # IMR enters then we're actually starting at age 0!
 #   if (!missing(IMR)) {
 #     if ( !is.na(IMR)){
@@ -141,7 +143,8 @@ qxmx2ax <- lt_id_qm_a
 #' @return lx vector of lifetable survivorship.
 #' @export
 lt_id_q_l <- function(nqx, radix = 1e5) {
-  if (as.character(match.call()[[1]]) == "qx2lx") {
+  fn_call <- deparse(match.call()[[1]])
+        if (identical(length(fn_call), 1L) && grepl("qx2lx$", fn_call)) {
     warning("please use lt_id_q_l() instead of qx2lx().", call. = FALSE)
   }
   radix * cumprod(c(1, 1 - nqx[-length(nqx)]))
@@ -163,7 +166,8 @@ qx2lx <- lt_id_q_l
 #' @return ndx vector of lifetable deaths.
 #' @export
 lt_id_l_d <- function(lx) {
-  if (as.character(match.call()[[1]]) == "lx2dx") {
+  fn_call <- deparse(match.call()[[1]])
+        if (identical(length(fn_call), 1L) && grepl("lx2dx$", fn_call)) {
     warning("please use lt_id_l_d() instead of lx2dx().", call. = FALSE)
   }
   diff(-c(lx, 0))
@@ -187,10 +191,11 @@ lx2dx <- lt_id_l_d
 #' @return nLx numeric vector of lifetable exposure.
 #' @export
 lt_id_lda_L <- function(lx, ndx, nax, AgeInt) {
-  if (as.character(match.call()[[1]]) == "lxdxax2Lx") {
+  fn_call <- deparse(match.call()[[1]])
+        if (identical(length(fn_call), 1L) && grepl("lxdxax2Lx$", fn_call)) {
     warning("please use lt_id_lda_L() instead of lxdxax2Lx().", call. = FALSE)
   }
-  
+
   N                   <- length(lx)
   nLx                 <- rep(0, N)
   nLx[1:(N - 1)]      <-
@@ -215,7 +220,8 @@ lxdxax2Lx <- lt_id_lda_L
 #' @return Tx total years left to live above age x.
 #' @export
 lt_id_L_T <- function(Lx) {
-  if (as.character(match.call()[[1]]) == "Lx2Tx") {
+  fn_call <- deparse(match.call()[[1]])
+        if (identical(length(fn_call), 1L) && grepl("Lx2Tx$", fn_call)) {
     warning("please use lt_id_L_T() instead of Lx2Tx().", call. = FALSE)
   }
   rev(cumsum(rev(Lx)))
@@ -250,26 +256,29 @@ Lx2Tx <- lt_id_L_T
 #' (lt_id_ma_q(2.1, ax, AgeInt, closeout = FALSE))
 
 lt_id_ma_q <- function(nMx, nax, AgeInt, closeout = TRUE, IMR) {
-  
-  if (as.character(match.call()[[1]]) == "mxax2qx_Backstop") {
+
+  fn_call <- deparse(match.call()[[1]])
+        if (identical(length(fn_call), 1L) && grepl("mxax2qx_Backstop$", fn_call)) {
     warning("please use lt_id_ma_q() instead of mxax2qx_Backstop().", call. = FALSE)
   }
 
-  if (as.character(match.call()[[1]]) == "mx2qx") {
+  fn_call <- deparse(match.call()[[1]])
+        if (identical(length(fn_call), 1L) && grepl("mx2qx$", fn_call)) {
     warning("please use lt_id_ma_q() instead of mx2qx().", call. = FALSE)
   }
-  if (as.character(match.call()[[1]]) == "mxax2qx") {
+  fn_call <- deparse(match.call()[[1]])
+        if (identical(length(fn_call), 1L) && grepl("mxax2qx$", fn_call)) {
     warning("please use lt_id_ma_q() instead of mxax2qx().", call. = FALSE)
   }
-  
+
   n <- length(nMx)
   stopifnot(n == length(nax))
   stopifnot(n == length(AgeInt))
-  
+
   # sometime assuming mid interval nAx causes the world
   # to turn upside down.
   qx <- (AgeInt * nMx) / (1 + (AgeInt - nax) * nMx)
-  
+
   if (closeout) {
     qx[length(qx)] <- 1
     if (length(nMx) == 1) {
@@ -278,14 +287,14 @@ lt_id_ma_q <- function(nMx, nax, AgeInt, closeout = TRUE, IMR) {
       )
     }
   }
-  # no Age argument, so strong assumption that if 
+  # no Age argument, so strong assumption that if
   # IMR enters then we're actually starting at age 0!
   if (!missing(IMR)) {
     if ( !is.na(IMR)){
       qx[1] <- IMR
     }
   }
-  
+
   # for cases where qx > 1 let's assume flat hazard inside interval,
   # in essence this overrides the nax given
   ind <- qx > 1
@@ -326,11 +335,12 @@ mxax2qx_Backstop <- lt_id_ma_q
 #' @param N integer, the age width for survivor ratios, either 5 or 1. Default 5.
 #' @export
 lt_id_Ll_S      <- function(nLx, lx, AgeInt, N = c(5, 1)) {
-  
-  if (as.character(match.call()[[1]]) == "Lxlx2Sx") {
+
+  fn_call <- deparse(match.call()[[1]])
+        if (identical(length(fn_call), 1L) && grepl("Lxlx2Sx$", fn_call)) {
     warning("please use lt_id_Ll_S() instead of Lxlx2Sx().", call. = FALSE)
   }
-  
+
   n               <- length(nLx)
   stopifnot(length(lx) == n)
   # either we're in 1 or 5 year age groups
@@ -362,9 +372,9 @@ lt_id_Ll_S      <- function(nLx, lx, AgeInt, N = c(5, 1)) {
     # closeout
     Sx[n]           <- nLx[n] / (nLx[n - 1] + nLx[n])
   }
-  
-  
-  
+
+
+
   Sx
 }
 #' @export

--- a/R/lt_rule.R
+++ b/R/lt_rule.R
@@ -89,18 +89,19 @@
 #' text(1, c(M0, M1_4, M0_4), c("M0", "M1_4", "M0_4"), pos = 3)
 #' }
 lt_rule_4m0_D0 <- function(D04, M04, P04, Sex = c("m", "f")) {
-  if (as.character(match.call()[[1]]) == "M04_2_D0") {
+  fn_call <- deparse(match.call()[[1]])
+  if (identical(length(fn_call), 1L) && grepl("M04_2_D0$", fn_call)) {
     warning("please use lt_rule_4m0_D0() instead of M04_2_D0().", call. = FALSE)
   }
-  
+
   if (missing(M04)) {
     M5 <- D04 / P04
   } else {
     M5 <- M04
   }
-  
+
   lM5   <- log(M5)
-  
+
   if (length(Sex)  == 1 & length(lM5) > 1) {
     Sex   <- rep(Sex, length(lM5))
   }
@@ -234,24 +235,25 @@ M04_2_D0 <- lt_rule_4m0_D0
 #' }
 
 lt_rule_4m0_m0 <- function(M04, D04, P04, Sex = c("m", "f")) {
-  if (as.character(match.call()[[1]]) == "M04_2_M0") {
+  fn_call <- deparse(match.call()[[1]])
+  if (identical(length(fn_call), 1L) && grepl("M04_2_M0$", fn_call)) {
     warning("please use lt_rule_4m0_m0() instead of M04_2_M0().", call. = FALSE)
   }
-  
-  
+
+
   if (missing(M04)) {
     M5 <- D04 / P04
   } else {
     M5 <- M04
   }
-  
+
   lM5   <- log(M5)
-  
+
   # handle lengths
   if (length(Sex)  == 1 & length(lM5) > 1) {
     Sex   <- rep(Sex, length(lM5))
   }
-  
+
   # ------------------------------
   # get coefs created
   coefs  <-
@@ -273,7 +275,7 @@ lt_rule_4m0_m0 <- function(M04, D04, P04, Sex = c("m", "f")) {
     coefs["int1", ] + coefs["s1", ] * coefs["brk", ] - s2 * coefs["brk", ]
   coefs  <- rbind(coefs, s2, int2)
   # ------------------------------
-  
+
   # based on a segmented regression of log(1D0/5D0)~log(5M0)
   lm0  <- ifelse(
     Sex == "m",
@@ -286,7 +288,7 @@ lt_rule_4m0_m0 <- function(M04, D04, P04, Sex = c("m", "f")) {
            coefs["int1", "f"] + lM5 * coefs["s1", "f"],
            coefs["int2", "f"] + lM5 * coefs["s2", "f"])
   )
-  
+
   # back to rate
   exp(lm0)
 }

--- a/R/lt_single.R
+++ b/R/lt_single.R
@@ -40,16 +40,17 @@ lt_single_mx <- function(nMx,
                              extrapFrom = max(Age),
                              extrapFit = Age[Age >= 60],
                              ...) {
-  if (as.character(match.call()[[1]]) == "lt_single_simple") {
+  fn_call <- deparse(match.call()[[1]])
+  if (identical(length(fn_call), 1L) && grepl("lt_single_simple$", fn_call)) {
     warning("please use lt_single_mx() instead of lt_single_simple().", call. = FALSE)
   }
-  
+
   stopifnot(extrapFrom <= max(Age))
-  
+
   Sex           <- tolower(Sex)
   region        <- tolower(region)
   extrapLaw     <- tolower(extrapLaw)
-  
+
   # setup Open Age handling
   OA            <- max(Age)
   # TR: save for later, in case OAG preserved
@@ -66,19 +67,19 @@ lt_single_mx <- function(nMx,
               x_extr = x_extr,
               law = extrapLaw,
               ...)
-  
+
   nMxext        <- Mxnew$values
   Age2          <- names2age(nMxext)
-  
+
   keepi         <- Age2 < extrapFrom
   nMxext[keepi] <- nMx[Age < extrapFrom]
-  
+
   # overwrite some variables:
   nMx           <- nMxext
   Age           <- Age2
   N             <- length(Age)
   AgeInt        <- rep(1, N)
-  
+
   # get ax:
   nAx           <- rep(.5, N)
   nAx[1]        <- lt_rule_1a0_cd(
@@ -86,14 +87,14 @@ lt_single_mx <- function(nMx,
                      IMR = IMR,
                      Sex = Sex,
                      region = region)
-  
+
   # get qx (if pathological qx > 1, ax replaced, assumed constant hazard)
   qx            <- lt_id_ma_q(
                      nMx = nMx,
                      nax = nAx,
-                     AgeInt = AgeInt, 
+                     AgeInt = AgeInt,
                      closeout = TRUE)
-  
+
   lx            <- lt_id_q_l(qx, radix = radix)
   ndx           <- lt_id_l_d(lx)
   nLx           <- lt_id_lda_L(
@@ -103,7 +104,7 @@ lt_single_mx <- function(nMx,
                      AgeInt = AgeInt)
   Tx            <- lt_id_L_T(nLx)
   ex            <- Tx / lx
-  
+
   # TR: now cut down due to closeout method (added 11 Oct 2018)
   ind           <- Age <= OAnew
   Age           <- Age[ind]
@@ -111,25 +112,25 @@ lt_single_mx <- function(nMx,
   nAx           <- nAx[ind]
   nMx           <- nMx[ind]
   qx            <- qx[ind]
-  
+
   lx            <- lx[ind]
-  
+
   # recalc dx from chopped lx
   ndx           <- lt_id_l_d(lx)
   nLx           <- nLx[ind]
   Tx            <- Tx[ind]
   ex            <- ex[ind]
-  
+
   # some closeout considerations
   N             <- length(qx)
   qx[N]         <- 1
   nLx[N]        <- Tx[N]
   nAx[N]        <- ex[N]
   AgeInt[N]     <- NA
-  
+
   # Survival ratios computed only after  nLx is closed out
   Sx            <- lt_id_Ll_S(nLx, lx, AgeInt = AgeInt, N = 1)
-  
+
   if (OAG) {
     if (OAnew == OA) {
       # keep first estimate if it was open and if we didn't extend
@@ -141,7 +142,7 @@ lt_single_mx <- function(nMx,
   } else {
     nMx[N]      <-  lx[N] / Tx[N]
   }
-  
+
   # output is an unrounded, unsmoothed lifetable
   out <- data.frame(
            Age = Age,

--- a/R/nAx.R
+++ b/R/nAx.R
@@ -60,28 +60,29 @@ lt_rule_1a0_cd <- function(M0,
                     IMR = NA,
                     Sex = "m",
                     region = "w") {
-  if (as.character(match.call()[[1]]) == "geta0CD") {
+  fn_call <- deparse(match.call()[[1]])
+  if (identical(length(fn_call), 1L) && grepl("geta0CD$", fn_call)) {
     warning("please use lt_rule_1a0_cd() instead of geta0CD().", call. = FALSE)
   }
-  
+
   # sex can be "m", "f", or "b"
   # region can be "n","e","s","w",or
   Sex       <- tolower(Sex)
   region    <- tolower(region)
-  
+
   Age0Const <- matrix(
-    c( 0.33, 0.35, 0.3500, 0.33, 
-       0.35, 0.3500, 0.29, 0.31, 
+    c( 0.33, 0.35, 0.3500, 0.33,
+       0.35, 0.3500, 0.29, 0.31,
        0.3100, 0.33, 0.35, 0.3500
     ),
     ncol = 3,
     byrow = TRUE,
     dimnames = list(c("w", "n", "e", "s"), c("m", "f", "b"))
   )
-  
+
   Intercept <- matrix(
-    c( 0.0425, 0.05, 0.0500, 0.0425, 
-       0.05, 0.0500, 0.0025, 0.01, 
+    c( 0.0425, 0.05, 0.0500, 0.0425,
+       0.05, 0.0500, 0.0025, 0.01,
        0.0100, 0.0425, 0.05, 0.0500
     ),
     ncol = 3,
@@ -90,7 +91,7 @@ lt_rule_1a0_cd <- function(M0,
   )
   Slope        <- c(2.875, 	3.000, 	3.0000)
   names(Slope) <- c("m", "f", "b")
-  
+
   Alpha        <- Intercept[region, Sex]
   Beta         <- Slope[Sex]
   # IMR optional here, use approximation
@@ -106,8 +107,8 @@ lt_rule_1a0_cd <- function(M0,
     }
   }
   ifelse(
-    IMR > .1, 
-    Age0Const[region, Sex], 
+    IMR > .1,
+    Age0Const[region, Sex],
     {Alpha + Beta * IMR})
 }
 
@@ -161,27 +162,28 @@ lt_rule_4a1_cd <- function(M0,
                       IMR = NA,
                       Sex = "m",
                       region = "w") {
-  if (as.character(match.call()[[1]]) == "geta1_4CD") {
+  fn_call <- deparse(match.call()[[1]])
+  if (identical(length(fn_call), 1L) && grepl("geta1_4CD$", fn_call)) {
     warning("please use lt_rule_4a1_cd() instead of geta1_4CD().", call. = FALSE)
   }
-  
+
   # sex can be "m", "f", or "b"
   # region can be "n","e","s","w",or
   Sex         <- tolower(Sex)
   region      <- tolower(region)
   Age1_4Const <- matrix(
-    c( 1.352, 1.361, 1.3610, 1.558, 
-       1.570, 1.5700, 1.313, 1.324, 
+    c( 1.352, 1.361, 1.3610, 1.558,
+       1.570, 1.5700, 1.313, 1.324,
        1.3240, 1.240, 1.239, 1.2390
     ),
     ncol = 3,
     byrow = TRUE,
     dimnames = list(c("w", "n", "e", "s"), c("m", "f", "b"))
   )
-  
+
   Intercept <- matrix(
-    c( 1.653, 1.524, 1.5240, 1.859, 
-       1.733, 1.7330, 1.614, 1.487, 
+    c( 1.653, 1.524, 1.5240, 1.859,
+       1.733, 1.7330, 1.614, 1.487,
        1.4870, 1.541, 1.402, 1.4020
     ),
     ncol = 3,
@@ -248,17 +250,18 @@ lt_a_pas <-
            Sex = "m",
            region = "w",
            OAG = TRUE) {
-    if (as.character(match.call()[[1]]) == "axPAS") {
+    fn_call <- deparse(match.call()[[1]])
+    if (identical(length(fn_call), 1L) && grepl("axPAS$", fn_call)) {
       warning("please use lt_a_pas() instead of axPAS().", call. = FALSE)
     }
     # sex can be "m", "f", or "b"
     # region can be "n","e","s","w",or
     Sex    <- tolower(Sex)
     region <- tolower(region)
-    
+
     N      <- length(nMx)
     ax     <- AgeInt / 2
-    
+
     ax[1]  <- lt_rule_1a0_cd(
                 M0 = nMx[1],
                 IMR = IMR,
@@ -269,7 +272,7 @@ lt_a_pas <-
                 IMR = IMR,
                 Sex = Sex,
                 region = region)
-  
+
     # TR 5-12-2019 this two-step returns midpoints IFF they
     # don't imply qx > 1, otherwise, for such pathological
     # values it returns the ax implied by a constant hazard.
@@ -283,14 +286,14 @@ lt_a_pas <-
     # # TR: this step vulnerable, see comment below.
     # ax <- lt_id_qm_a(nqx = qx, nMx = nMx, AgeInt = AgeInt)
     ax[N]  <- ifelse(OAG, 1 / nMx[N], ax[N])
-    
+
     # TR 31-12-2019 at this point, transitivity is guaranteed internally for
     # qx, mx, and ax, however, a0 may have been determied by IMR, and in this
     # case q0 (just created above) might be different from IMR (likely so), AND
     # the a0 might be negative or greater than 1, which simply cannot be. It
     # should be preferred to EITHER override M0 downstream (beyond this function call)
     # OR remove the IMR option altogether.
-    
+
     # ind <- impliedqx > 1
     # if (sum(ind) > 0) {
     #   for (i in which(ind)) {
@@ -302,7 +305,7 @@ lt_a_pas <-
     #                      AgeInt = AgeInt[i])
     #   }
     # }
-    
+
     ax
   }
 
@@ -387,22 +390,23 @@ lt_id_morq_a_greville <- function(nMx,
                                   extrapFrom = max(Age),
                                   extrapFit = Age[Age >= 60],
                                   ...) {
-  if (as.character(match.call()[[1]]) == "ax.greville.mortpak") {
+  fn_call <- deparse(match.call()[[1]])
+  if (identical(length(fn_call), 1L) && grepl("ax.greville.mortpak$", fn_call)) {
     warning("please use lt_id_morq_a_greville() instead of ax.greville.mortpak().", call. = FALSE)
   }
-  
+
   Sex     <- tolower(Sex)
   region  <- tolower(region)
   law     <- tolower(law)
   DBL_MIN <- .Machine$double.xmin
-  
+
   # sort out arguments:
   mxflag  <- missing(nMx)
   qxflag  <- missing(nqx)
   imr_flag <- !is.na(IMR)
-  
 
-  
+
+
   # if no qx, we can get from lx if available
   if (qxflag & !missing(lx)) {
     nqx <- lt_id_l_d(lx) / lx
@@ -412,10 +416,10 @@ lt_id_morq_a_greville <- function(nMx,
     # preserve IMR like so
     nqx[1] <- IMR
   }
-  
+
   stopifnot(!qxflag | !mxflag)
   # now we have either qx or mx
-  
+
   if (!mxflag) {
     a0     <- lt_rule_1a0_cd(
                 M0 = nMx[1],
@@ -447,15 +451,15 @@ lt_id_morq_a_greville <- function(nMx,
     nMx    <- nqx
     qind   <- TRUE
   }
-  
-  
+
+
   # some setup
   N           <- length(nMx)
-  
+
   ## for ages 15-19 onward
   ## AK <- log(QxMx[j+1]/QxMx[j-1])/10 ## we don't have 1/10 ?
   ## ax[j] <- 2.5 - (25.0/12.0) * (QxMx[j] - AK)
-  
+
   ## improved Greville formula for adolescent ages 5-9 and 10-14
   ## Let the three successive lengths be n1, n2 and n3, the formula for 5a5 is:
   ## ax[i] = 2.5 - (25 / 12) * (mx[i] - log(mx[i + 1] / mx[i-1])/(n1/2+n2+n3/2))
@@ -463,46 +467,46 @@ lt_id_morq_a_greville <- function(nMx,
   ## has only 4 ages (not 5), while the other 5-year age group are 1/10
   ## ax[i] = 2.5 - (25 / 12) * (mx[i] - (1/9.5)* log(mx[i + 1] / mx[i-1]))
   ## Age 20-25, ..., 95-99
-  
+
   # TR: 6-3-2020 remove pointless loop, add in new back stop
-  
+
   # constant hazard ax, as filler for pathological cases:
   axConst <- AgeInt + 1 / nMx - AgeInt / (1 - exp(-AgeInt * nMx))
   # inverse of weighted moving avg age interval.
   Abx     <- 1 / (shift.vector(AgeInt,1, fill = NA) / 2 + AgeInt + shift.vector(AgeInt,-1, fill = NA) / 2)
   # Kx is fragile
-  Kx      <- log(pmax(shift.vector(nMx,-1, fill = NA),DBL_MIN) / 
+  Kx      <- log(pmax(shift.vector(nMx,-1, fill = NA),DBL_MIN) /
                    pmax(shift.vector(nMx,1, fill = NA),DBL_MIN)) # / 10?
   # This does nothing special for age 5-9, which has a 4-year age group on the left.
   # age 1-4 is overwritten anyway.
   ax      <- AgeInt / 2 - (AgeInt ^ 2 / 12) * (nMx - Kx * Abx)
-  
+
   # pick out likely pathological cases and imput w const ax
   ind     <- Age >= 10 & Age < max(Age) & (ax < (.4 * AgeInt) | ax > (.6 * AgeInt)) | is.na(ax)
   ax[ind] <- axConst[ind]
-  
+
   # TR: remove this, superceded by axConst filler.
   ## (Mortpak used 1 instead of 0.97).
   # if (Age[i] > 35 && ax[i] < 0.97) {
   #   ax[i] <- 0.97
   # }
-  
-  
-  # preserve old patch for 
+
+
+  # preserve old patch for
   if (qind){
     axfill   <- shift.vector(ax,1, fill = NA) * .8
     ind      <- Age >= 65 & ax < axfill
     ax[ind]  <- axfill[ind]
   }
-  
+
   # a1_4 only valid for abridged
   ax[1:2] <- c(a0, a1_4)
-  
+
   # TR: this is questionable now
   if (!mod) {
     ax[3:4] <- AgeInt[3:4] / 2
   }
-  
+
   # closeout
   if (max(Age) < 130 & closeout) {
     aomega         <- lt_a_closeout(
@@ -512,7 +516,7 @@ lt_id_morq_a_greville <- function(nMx,
                          extrapFrom = extrapFrom,
                          extrapFit = extrapFit,
                          ...)
-    
+
     ax[N]          <- aomega
   } else {
     ax[N]          <- 1 / nMx[N]
@@ -604,21 +608,22 @@ lt_a_un <- function(nMx,
                  extrapFrom = max(Age),
                  extrapFit = Age[Age >= 60],
                  ...) {
-  if (as.character(match.call()[[1]]) == "axUN") {
+  fn_call <- deparse(match.call()[[1]])
+  if (identical(length(fn_call), 1L) && grepl("axUN$", fn_call)) {
     warning("please use lt_a_un() instead of axUN().", call. = FALSE)
   }
-  
+
   stopifnot(!missing(nqx) | !missing(nMx))
   smsq    <- 99999
   Sex     <- tolower(Sex)
   region  <- tolower(region)
   law     <- tolower(extrapLaw)
-  
+
   if (missing(nqx) & !missing(lx)) {
     nqx <- lt_id_l_d(lx) / lx
   }
   # now we have either nqx or nMx
-  
+
   if (missing(nqx) & !missing(nMx)) {
     # UN (1982) p 31
     # http://www.un.org/esa/population/publications/Model_Life_Tables/Model_Life_Tables.htm
@@ -661,7 +666,7 @@ lt_a_un <- function(nMx,
       extrapFit = extrapFit,
       ...
     )
-    
+
     for (i in 1:maxit) {
       mxi   <- lt_id_qa_m(
                     nqx = nqx,
@@ -704,7 +709,7 @@ lt_a_un <- function(nMx,
                    nMx = nMx,
                    AgeInt = AgeInt)
   }
-  
+
   #	if (closeout == "mortpak" & sum(AgeInt) < 100){
   #		N      <- length(axi)
   #		aomega <- aomegaMORTPAK(mx_or_qx                                                                       = nMx, qind = FALSE)
@@ -726,8 +731,8 @@ lt_a_un <- function(nMx,
   } else {
     axi[N] <- 1 / nMx[N]
   }
-  
-  
+
+
   # if mx, qx, or both are given, then by now we have ax
   axi
 }
@@ -778,14 +783,15 @@ lt_a_closeout <- function(mx,
                           extrapFrom = max(Age),
                           extrapFit = Age[Age >= 40],
                           ...) {
-  if (as.character(match.call()[[1]]) == "aomegaMortalityLaws") {
+  fn_call <- deparse(match.call()[[1]])
+  if (identical(length(fn_call), 1L) && grepl("aomegaMortalityLaws$", fn_call)) {
     warning("please use lt_a_closeout() instead of aomegaMortalityLaws().", call. = FALSE)
   }
-  
+
   extrapLaw <- tolower(law)
   OA        <- max(Age)
   x_extr    <- seq(OA, 130, by = .1)
-  
+
   Mxnew     <- lt_rule_m_extrapolate(
     mx = mx,
     x = Age,
@@ -796,12 +802,12 @@ lt_a_closeout <- function(mx,
   )
   mmxx      <- Mxnew$values
   mx        <- mmxx[names2age(mmxx) >= OA]
-  
+
   # acceptable approximation for small intervals
   lx        <- c(1, exp(-cumsum(mx / 10)), 0)
   # divide by 10 (interval) and 2 (avg), so 20.
   sum(shift.vector(lx, -1) + lx) / 20
-  
+
 }
 
 #' @export
@@ -844,10 +850,11 @@ lt_id_morq_a <- function(nMx,
                       extrapFrom = max(Age),
                       extrapFit = Age[Age >= 60],
                       ...) {
-  if (as.character(match.call()[[1]]) == "mxorqx2ax") {
+  fn_call <- deparse(match.call()[[1]])
+  if (identical(length(fn_call), 1L) && grepl("mxorqx2ax$", fn_call)) {
     warning("please use lt_id_morq_a() instead of mxorqx2ax().", call. = FALSE)
   }
-  
+
   N <- length(AgeInt)
   if (is.na(AgeInt[N]) | is.infinite(AgeInt[N])) {
     AgeInt[N] <- AgeInt[N - 1]
@@ -861,8 +868,8 @@ lt_id_morq_a <- function(nMx,
                      IMR = IMR,
                      Sex = Sex,
                      region = region,
-                     OAG = OAG)             
-      
+                     OAG = OAG)
+
     } else {
       # if nMx avail, then Open age group
       # closed according to convention.
@@ -892,7 +899,7 @@ lt_id_morq_a <- function(nMx,
                      extrapFrom = extrapFrom,
                      extrapFit = extrapFit,
                      ...)
-      
+
     } else {
       nAx       <- lt_a_un(
                      nMx = nMx,
@@ -907,7 +914,7 @@ lt_id_morq_a <- function(nMx,
                      extrapFit = extrapFit,
                      ...)
     }
-    
+
   }
   nAx
 }

--- a/R/smooth_age_5.R
+++ b/R/smooth_age_5.R
@@ -28,10 +28,11 @@
 smooth_age_5_cf <- function(Value,
                                 Age,
                                 OAG = TRUE) {
-  if (as.character(match.call()[[1]]) == "carrier_farrag_smth") {
+  fn_call <- deparse(match.call()[[1]])
+  if (identical(length(fn_call), 1L) && grepl("carrier_farrag_smth$", fn_call)) {
     warning("please use smooth_age_5_cf() instead of carrier_farrag_smth().", call. = FALSE)
   }
-  
+
   # these values are not used, it's just for lengths, and to make sure we
   # end on an even 10. Technically we could even provide data in 10-year
   # age groups and it'd still not break.
@@ -40,28 +41,28 @@ smooth_age_5_cf <- function(Value,
     groupAges(Value1, Age = as.integer(names(Value1)), N = 5)
   N          <- length(Value5)
   Age5       <- as.integer(names(Value5))
-  
+
   # would need to move this up to ensure?
   # or in case of 85+ would we want to keep 80-84, 85+ as-is?
   Value10    <- groupAges(Value, Age = Age, N = 10)
-  
+
   # what OAG is a strange digit? Then take OAG after grouping.
   if (OAG) {
     OAGvalue <- Value10[length(Value10)]
     Value10[length(Value10)] <- NA
   }
-  
+
   v10R       <- shift.vector(Value10, 1, fill = NA)
   v10L       <- shift.vector(Value10,-1, fill = NA)
   vevens     <- Value10 / (1 + (v10R / v10L) ^ .25)
   vodds      <- Value10 - vevens
-  
+
   out        <- Value5 * NA
   # cut back down (depending) and name
   interleaf  <- c(rbind(vodds, vevens))
   n          <- min(c(length(interleaf), N))
   out[1:n]   <- interleaf[1:n]
-  
+
   out
   # tail behavior will be controlled in top level function.
 }
@@ -96,10 +97,11 @@ carrier_farrag_smth <- smooth_age_5_cf
 smooth_age_5_kkn <- function(Value,
                      Age,
                      OAG = TRUE) {
-  if (as.character(match.call()[[1]]) == "kkn_smth") {
+  fn_call <- deparse(match.call()[[1]])
+  if (identical(length(fn_call), 1L) && grepl("kkn_smth$", fn_call)) {
     warning("please use smooth_age_5_kkn() instead of kkn_smth().", call. = FALSE)
   }
-  
+
   # these values are not used, it's just for lengths, and to make sure we
   # end on an even 10. Technically we could even provide data in 10-year
   # age groups and it'd still not break.
@@ -108,20 +110,20 @@ smooth_age_5_kkn <- function(Value,
     groupAges(Value1, Age = as.integer(names(Value1)), N = 5)
   N          <- length(Value5)
   Age5       <- as.integer(names(Value5))
-  
+
   # would need to move this up to ensure?
   # or in case of 85+ would we want to keep 80-84, 85+ as-is?
   Value10    <- groupAges(Value, Age = Age, N = 10)
-  
+
   # what OAG is a strange digit? Then take OAG after grouping.
   if (OAG) {
     OAGvalue <- Value10[length(Value10)]
     Value10[length(Value10)] <- NA
   }
-  
+
   v10R       <- shift.vector(Value10, 1, fill = NA)
   v10L       <- shift.vector(Value10,-1, fill = NA)
-  
+
   # this is the KNN operation
   vodds      <- Value10 / 2 + (v10R - v10L) / 16
   # constrained in 10-year age groups
@@ -132,7 +134,7 @@ smooth_age_5_kkn <- function(Value,
   out        <- Value5 * NA
   n          <- min(c(length(interleaf), N))
   out[1:n]   <- interleaf[1:n]
-  
+
   out
 }
 #' @export
@@ -168,10 +170,11 @@ kkn_smth <- smooth_age_5_kkn
 smooth_age_5_arriaga <- function(Value,
                          Age,
                          OAG = TRUE) {
-  if (as.character(match.call()[[1]]) == "arriaga_smth") {
+  fn_call <- deparse(match.call()[[1]])
+  if (identical(length(fn_call), 1L) && grepl("arriaga_smth$", fn_call)) {
     warning("please use smooth_age_5_arriaga() instead of arriaga_smth().", call. = FALSE)
   }
-  
+
   # these values are not used, it's just for lengths, and to make sure we
   # end on an even 10. Technically we could even provide data in 10-year
   # age groups and it'd still not break.
@@ -180,24 +183,24 @@ smooth_age_5_arriaga <- function(Value,
     groupAges(Value1, Age = as.integer(names(Value1)), N = 5)
   N          <- length(Value5)
   Age5       <- as.integer(names(Value5))
-  
+
   # would need to move this up to ensure?
   # or in case of 85+ would we want to keep 80-84, 85+ as-is?
   Value10    <- groupAges(Value, Age = Age, N = 10)
-  
+
   # what OAG is a strange digit? Then take OAG after grouping.
   if (OAG) {
     OAGvalue <- Value5[length(Value5)]
     Value10[length(Value10)] <- NA
     Value5[length(Value5)]   <- NA
   }
-  
+
   # again get staggered vectors
   Value10LL   <- shift.vector(Value10,-2, fill = NA)
   Value10L    <- shift.vector(Value10,-1, fill = NA)
   Value10R    <- shift.vector(Value10, 1, fill = NA)
   Value10RR   <- shift.vector(Value10, 2, fill = NA)
-  
+
   # alternating calc, with differences at tails
   vevens      <- (-Value10R + 11 * Value10 + 2 * Value10L) / 24
   # tails different
@@ -208,21 +211,21 @@ smooth_age_5_arriaga <- function(Value,
     Value10[lastind] - (8 * Value10[lastind] + 5 * Value10R[lastind] - Value10RR[lastind]) / 24
   # odds are complement
   vodds       <- Value10 - vevens
-  
+
   # prepare output
   interleaf  <- c(rbind(vodds, vevens))
   # produce results vector
   out        <- Value5 * NA
   n          <- min(c(length(interleaf), N))
   out[1:n]   <- interleaf[1:n]
-  
+
   # if OA ends in 5, then we can save penultimate value too
   na.i       <- is.na(out)
   out[na.i]  <- Value5[na.i]
   if (OAG) {
     out[N] <- OAGvalue
   }
-  
+
   out
 }
 #' @export
@@ -255,30 +258,31 @@ arriaga_smth <- smooth_age_5_arriaga
 smooth_age_5_un <- function(Value,
                                 Age,
                                 OAG = TRUE) {
-  if (as.character(match.call()[[1]]) == "united_nations_smth") {
+  fn_call <- deparse(match.call()[[1]])
+  if (identical(length(fn_call), 1L) && grepl("united_nations_smth$", fn_call)) {
     warning("please use smooth_age_5_un() instead of united_nations_smth().", call. = FALSE)
   }
-  
+
   N <- length(Value)
   if (OAG) {
     Value[N] <- NA
   }
-  
+
   Value5     <- groupAges(Value, Age = Age, N = 5)
   N          <- length(Value5)
   Age5       <- as.integer(names(Value5))
-  
+
   # get staggered vectors
   Value5LL   <- shift.vector(Value5,-2, fill = NA)
   Value5L    <- shift.vector(Value5,-1, fill = NA)
   Value5R    <- shift.vector(Value5, 1, fill = NA)
   Value5RR   <- shift.vector(Value5, 2, fill = NA)
-  
+
   # this is the funny KNN operation
   # B11 is central
   out  <-
     (-Value5RR + 4 * (Value5L + Value5R) + 10 * Value5 - Value5LL) / 16
-  
+
   # cut back down (depending) and name
   names(out) <- Age5
   out
@@ -319,10 +323,11 @@ smooth_age_5_strong <- function(Value,
                         OAG = TRUE,
                         ageMin = 10,
                         ageMax = 65) {
-  if (as.character(match.call()[[1]]) == "strong_smth") {
+  fn_call <- deparse(match.call()[[1]])
+  if (identical(length(fn_call), 1L) && grepl("strong_smth$", fn_call)) {
     warning("please use smooth_age_5_strong() instead of strong_smth().", call. = FALSE)
   }
-  
+
   # these values are not used, it's just for lengths, and to make sure we
   # end on an even 10. Technically we could even provide data in 10-year
   # age groups and it'd still not break.
@@ -331,11 +336,11 @@ smooth_age_5_strong <- function(Value,
     groupAges(Value1, Age = as.integer(names(Value1)), N = 5)
   N          <- length(Value5)
   Age5       <- as.integer(names(Value5))
-  
+
   # would need to move this up to ensure?
   # or in case of 85+ would we want to keep 80-84, 85+ as-is?
   Value10    <- groupAges(Value, Age = Age, N = 10)
-  
+
   # what OAG is a strange digit? Then take OAG after grouping.
   if (OAG) {
     OAGvalue <- Value5[length(Value5)]
@@ -344,11 +349,11 @@ smooth_age_5_strong <- function(Value,
   }
   Age5       <- as.integer(names(Value5))
   Age10      <- as.integer(names(Value10))
-  
+
   # subtotal
   indsub     <- Age10 >= ageMin & Age10 <= ageMax
   SubTot     <- sum(Value10[indsub])
-  
+
   #	# get staggered vectors
   Value10L    <- shift.vector(Value10,-1, fill = NA)
   Value10R    <- shift.vector(Value10, 1, fill = NA)
@@ -356,18 +361,18 @@ smooth_age_5_strong <- function(Value,
   # B11 is central
   Value10Pert <- (Value10 * 2 + Value10L + Value10R) / 4
   Value10Pert[is.na(Value10Pert)] <- Value10[is.na(Value10Pert)]
-  
+
   # rescale ages between min and max to sum to original
   Value10Adj  <- Value10Pert
   Value10Adj[indsub] <-
     Value10Adj[indsub] * SubTot / sum(Value10Adj[indsub])
-  
+
   # again get staggered vectors
   V10adjLL    <- shift.vector(Value10Adj,-2, fill = NA)
   V10adjL     <- shift.vector(Value10Adj,-1, fill = NA)
   V10adjR     <- shift.vector(Value10Adj, 1, fill = NA)
   V10adjRR    <- shift.vector(Value10Adj, 2, fill = NA)
-  
+
   # alternating calc, with differences at tails
   vevens     <- (-V10adjR + 11 * Value10Adj + 2 * V10adjL) / 24
   # tails different
@@ -378,7 +383,7 @@ smooth_age_5_strong <- function(Value,
     Value10Adj[lastind] - (8 * Value10Adj[lastind] + 5 * V10adjR[lastind] - V10adjRR[lastind]) / 24
   # odds are complement
   vodds      <- Value10Adj - vevens
-  
+
   # prepare output
   # prepare output
   interleaf  <- c(rbind(vodds, vevens))
@@ -386,14 +391,14 @@ smooth_age_5_strong <- function(Value,
   out        <- Value5 * NA
   n          <- min(c(length(interleaf), N))
   out[1:n]   <- interleaf[1:n]
-  
+
   # if OA ends in 5, then we can save penultimate value too
   na.i       <- is.na(out)
   out[na.i]  <- Value5[na.i]
   if (OAG) {
     out[N] <- OAGvalue
   }
-  
+
   # what if OAis e.g. 85?
   out
 }
@@ -426,14 +431,15 @@ smooth_age_5_zigzag <- function(Value,
                         OAG = TRUE,
                         ageMin = 40,
                         ageMax = max(Age) - max(Age) %% 10 - 5) {
-  
-  if (as.character(match.call()[[1]]) == "zigzag_smth") {
+
+  fn_call <- deparse(match.call()[[1]])
+  if (identical(length(fn_call), 1L) && grepl("zigzag_smth$", fn_call)) {
     warning("please use smooth_age_5_zigzag() instead of zigzag_smth().", call. = FALSE)
   }
   # insist on 5-year age groups
   Value <- groupAges(Value, Age = Age, N = 5)
   Age   <- as.integer(names(Value))
-  
+
   Smoothed <- smooth_age_5_zigzag_inner(
     Value = Value,
     Age = Age,
@@ -443,7 +449,7 @@ smooth_age_5_zigzag <- function(Value,
   )
   # put NAs in for unadjusted ages,
   Smoothed[Smoothed == Value] <- NA
-  
+
   Smoothed
 }
 
@@ -482,19 +488,20 @@ smooth_age_5_mav <- function(Value,
                      Age,
                      OAG = TRUE,
                      n = 3) {
-  if (as.character(match.call()[[1]]) == "mav_smth") {
+  fn_call <- deparse(match.call()[[1]])
+  if (identical(length(fn_call), 1L) && grepl("mav_smth$", fn_call)) {
     warning("please use smooth_age_5_mav() instead of mav_smth().", call. = FALSE)
   }
   Value <- groupAges(Value, Age = Age, N = 5)
   Age   <- as.integer(names(Value))
-  
+
   Smoothed <- mav(
     Value = Value,
     Age = Age,
     OAG = OAG,
     n = n
   )
-  
+
   Smoothed
 }
 
@@ -560,14 +567,15 @@ smooth_age_5_feeney          <- function(Value,
                                          Age,
                                          maxit = 200,
                                          OAG = FALSE) {
-  if (as.character(match.call()[[1]]) == "T9R5L") {
+  fn_call <- deparse(match.call()[[1]])
+  if (identical(length(fn_call), 1L) && grepl("T9R5L$", fn_call)) {
     warning("please use smooth_age_5_feeney() instead of T9R5L().", call. = FALSE)
   }
-  
+
   # ages need to be single to use this method.
   stopifnot(is_single(Age))
   TOT          <- sum(Value, na.rm = TRUE)
-  
+
   # handle OAG with care
   if (OAG) {
     NN         <- length(Value)
@@ -575,18 +583,18 @@ smooth_age_5_feeney          <- function(Value,
     OA         <- Age[NN]
     Value      <- Value[-NN]
     Age        <- Age[-NN]
-    
+
   }
-  
+
   V5           <- groupAges(Value, Age, N = 5)
   A5           <- names2age(V5)
   i5           <- Age %% 5 == 0
-  
+
   # TR: is this length-vulnerable?
   V50          <- Value[i5]
   V54          <- V5 - V50
-  
-  
+
+
   # need N anyway
   N            <- length(V5)
   # internal function used iteratively
@@ -602,8 +610,8 @@ smooth_age_5_feeney          <- function(Value,
     aj         <- list(FC, POB1, POB2)
     aj
   }
-  
-  
+
+
   # adjustment loop
   for (i in 1:maxit) {
     adjust     <- f_adjust(v5 = V50, v4 = V54)
@@ -613,16 +621,16 @@ smooth_age_5_feeney          <- function(Value,
       break
     }
   }
-  
+
   G            <- (V50 * .6)[c(2:(N - 1))]
   H            <- (V50 * .4)[c(3:N)]
   I            <- G + H #f(x+2.5)
-  
+
   # corrected, but unknowns still need to be redistributed
   #I5          <- rescale_vector(I * 5,sum(V5[2:(N-1)]))
   I5           <- I * 5
   out          <- c(V5[1], I5, V5[N])
-  
+
   if (OAG) {
     A5         <- c(A5, OA)
     out        <- c(out, OAvalue)
@@ -783,10 +791,11 @@ smooth_age_5 <- function(Value,
                     n = 3,
                     young.tail = c("Original", "Arriaga", "Strong", NA),
                     old.tail = young.tail) {
-  if (as.character(match.call()[[1]]) == "agesmth") {
+  fn_call <- deparse(match.call()[[1]])
+  if (identical(length(fn_call), 1L) && grepl("agesmth$", fn_call)) {
     warning("please use smooth_age_5() instead of agesmth().", call. = FALSE)
   }
-  
+
   method <- match.arg(method, c("Carrier-Farrag",
                                 "KKN",
                                 "Arriaga",
@@ -796,13 +805,13 @@ smooth_age_5 <- function(Value,
                                 "MAV"))
   young.tail <- match.arg(young.tail, c("Original", "Arriaga", "Strong", NA))
   old.tail   <- match.arg(old.tail, c("Original", "Arriaga", "Strong", NA))
-  
+
   method     <- simplify.text(method)
   young.tail <- simplify.text(young.tail)
   old.tail   <- simplify.text(old.tail)
- 
-  
-   
+
+
+
   if (missing(Age)) {
     Age      <- as.integer(names(Value))
   }
@@ -813,7 +822,7 @@ smooth_age_5 <- function(Value,
                                Age = Age,
                                OAG = OAG)
   }
-  
+
   # stong
   if (method == "strong") {
     out <-
@@ -825,21 +834,21 @@ smooth_age_5 <- function(Value,
         ageMax = ageMax
       )
   }
-  
+
   # un or unitednations
   if (method %in% c("un", "unitednations")) {
     out <- smooth_age_5_un(Value = Value,
                                Age = Age,
                                OAG = OAG)
   }
-  
+
   # arriaga
   if (method  == "arriaga") {
     out <- smooth_age_5_arriaga(Value = Value,
                         Age = Age,
                         OAG = OAG)
   }
-  
+
   # kkn kkingnewton karupkingnewton
   if (method %in% c("kkn", "kkingnewton", "karupkingnewton")) {
     out <- smooth_age_5_kkn(Value = Value,
@@ -868,7 +877,7 @@ smooth_age_5 <- function(Value,
              OAG = OAG,
              maxit = 200)
   }
-  
+
   if (method %in% c("mav", "ma", "movingaverage")) {
     # however, need to make it so NAs returned in unaffected ages?
     # or make the user call it in various runs and graft together.
@@ -905,7 +914,7 @@ smooth_age_5 <- function(Value,
         stopifnot(length(strong) == length(out))
         out[old.ind] <- strong[old.ind]
       }
-      
+
     }
     nrle             <- rle(as.integer(nas))
     # take care of young tail
@@ -913,7 +922,7 @@ smooth_age_5 <- function(Value,
       nrle$values[length(nrle$values)] <- 0
       young.ind        <-
         as.logical(rep(nrle$values, times = nrle$lengths))
-      
+
       if (young.tail %in% c("o", "orig", "original")) {
         stopifnot(length(original) == length(out))
         out[young.ind] <- original[young.ind]
@@ -930,7 +939,7 @@ smooth_age_5 <- function(Value,
       }
     }
   } # end tail operations
-  
+
   out
 }
 

--- a/R/utils.R
+++ b/R/utils.R
@@ -18,7 +18,7 @@
 #' @export
 shift.vector <- function(x, shift = 0, fill = FALSE) {
   n          <- length(x)
-  
+
   if (shift > 0) {
     x        <- c(rep(fill, shift), x[-((n - shift + 1):n)])
   }
@@ -89,10 +89,11 @@ ma <- function(x, n = 5) {
 #' @export
 
 rescale_vector <- function(x, scale = 1) {
-  if (as.character(match.call()[[1]]) == "adjustAge") {
+  fn_call <- deparse(match.call()[[1]])
+  if (identical(length(fn_call), 1L) && grepl("adjustAge$", fn_call)) {
     warning("please use rescale_vector() instead of adjustAge().", call. = FALSE)
   }
-  
+
   scale * x / sum(x, na.rm = TRUE)
 }
 
@@ -151,7 +152,7 @@ ypart           <-
            detect.mid.year = TRUE,
            detect.start.end = TRUE) {
     M           <- c(0, 31, 59, 90, 120, 151, 181, 212, 243, 273, 304, 334)
-    
+
     if (detect.mid.year) {
       .d        <- as.integer(Day)
       .m        <- as.integer(Month)
@@ -159,7 +160,7 @@ ypart           <-
         return(.5)
       }
     }
-    
+
     if (detect.start.end) {
       .d        <- as.integer(Day)
       .m        <- as.integer(Month)
@@ -170,12 +171,12 @@ ypart           <-
         return(1)
       }
     }
-    
+
     monthdur    <- diff(c(M, 365))
     monthdur[2] <- monthdur[2] + is_LeapYear(Year)
     M           <- cumsum(monthdur) - 31
     return((M[Month] + Day) / sum(monthdur))
-    
+
   }
 
 
@@ -250,12 +251,12 @@ ratx   <- function(fx, k = 1) {
 #' @export
 getModelLifeTable <- function(ModelName, Sex) {
   Sex             <- toupper(substr(Sex, 1, 1))
-  
+
   stopifnot(Sex %in% c("M", "F"))
   stopifnot(ModelName == "coale-demeny west")
-  
+
   outputLT        <- demogR::cdmltw(sex = Sex)
-  
+
   return(outputLT)
 }
 

--- a/tests/testthat/test-fn_name_check_message.R
+++ b/tests/testthat/test-fn_name_check_message.R
@@ -1,0 +1,68 @@
+context("warnings based on name of called function")
+
+test_that("calling 'Whipple' produces a warning", {
+
+    expect_warning(Whipple(Value = 25:65, Age = 25:65), "please use")
+    expect_warning(Whipple(Value = 25:65, Age = 25:65), "please use")
+    expect_warning(do.call("Whipple",
+                           args = list(Value = 25:65, Age = 25:65)), "please use")
+
+    ## Invoking 'do.call' in these forms does not let 'match.call' see
+    ## the function name so any use of the old function name will not
+    ## be caught.
+    expect_warning(do.call(match.fun("Whipple"),
+                           args = list(Value = 25:65, Age = 25:65)), NA)
+    expect_warning(do.call(Whipple,
+                           args = list(Value = 25:65, Age = 25:65)), NA)
+    expect_warning(do.call(match.fun(Whipple),
+                           args = list(Value = 25:65, Age = 25:65)), NA)
+
+})
+
+test_that("calling 'DemoTools::Whipple' proudces a warning", {
+
+    expect_warning(DemoTools::Whipple(Value = 25:65, Age = 25:65), "please use")
+    expect_warning(DemoTools::Whipple(Value = 25:65, Age = 25:65), "please use")
+
+    ## Invoking 'do.call' in these forms does not let 'match.call' see
+    ## the function name so any use of the old function name will not
+    ## be caught.
+    expect_warning(do.call(DemoTools::Whipple,
+                           args = list(Value = 25:65, Age = 25:65)), NA)
+    expect_warning(do.call(match.fun(DemoTools::Whipple),
+                           args = list(Value = 25:65, Age = 25:65)), NA)
+})
+
+
+test_that("calling 'check_heaping_whipple' does not produce a warning", {
+
+    expect_warning(check_heaping_whipple(Value = 25:65, Age = 25:65), NA)
+    expect_warning(check_heaping_whipple(Value = 25:65, Age = 25:65), NA)
+    expect_warning(do.call("check_heaping_whipple",
+                           args = list(Value = 25:65, Age = 25:65)), NA)
+
+    ## Invoking 'do.call' in these forms does not let 'match.call' see
+    ## the function name so any use of the old function name will not
+    ## be caught.
+    expect_warning(do.call(match.fun("check_heaping_whipple"),
+                           args = list(Value = 25:65, Age = 25:65)), NA)
+    expect_warning(do.call(check_heaping_whipple,
+                           args = list(Value = 25:65, Age = 25:65)), NA)
+    expect_warning(do.call(match.fun(check_heaping_whipple),
+                           args = list(Value = 25:65, Age = 25:65)), NA)
+
+})
+
+test_that("calling 'DemoTools::check_heaping_whipple' does not produce a warning", {
+
+    expect_warning(DemoTools::check_heaping_whipple(Value = 25:65, Age = 25:65), NA)
+    expect_warning(DemoTools::check_heaping_whipple(Value = 25:65, Age = 25:65), NA)
+
+    ## Invoking 'do.call' in these forms does not let 'match.call' see
+    ## the function name so any use of the old function name will not
+    ## be caught.
+    expect_warning(do.call(DemoTools::check_heaping_whipple,
+                           args = list(Value = 25:65, Age = 25:65)), NA)
+    expect_warning(do.call(match.fun(DemoTools::check_heaping_whipple),
+                           args = list(Value = 25:65, Age = 25:65)), NA)
+})


### PR DESCRIPTION
In many functions there is a check for the name of the called function, e.g., `if (as.character(match.call()[[1]]) == "lt_single_simple")` in 'R/lt_single.R'. This fails if the function is called with a namespace, e.g., `DemoTools::lt_single_mx`. This occurs, for example, when invoked in another package. The update attempts to fix this and, additionally, offer some support for other methods of calling via `do.call`.

A test for the `check_heaping_whipple` function has been included in file 'tests/testthat/test-fn_name_check_messages.R'.

`devtools::check` completed with the following message:

```
-- R CMD check results --------------------------------- DemoTools 01.06.02 ----
Duration: 5m 35.2s

> checking data for ASCII and uncompressed saves ... OK
   WARNING
  'qpdf' is needed for checks on size reduction of PDFs

0 errors v | 1 warning x | 0 notes v
```

Reference: The `deparse` idea is from "GavinSimpson"s comment half way down this page: https://stackoverflow.com/questions/15595478/how-to-get-the-name-of-the-calling-function-inside-the-called-routine