### PR TITLE
Removes tidyverse deps and adds ggplot2 in suggests

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -29,7 +29,7 @@ Suggests:
     knitr,
     rmarkdown,
     DT,
-    tidyverse,
+    ggplot2,
     bibtex (>= 0.4.2)
 RdMacros: Rdpack
 Imports:

--- a/vignettes/migration_with_demotools.Rmd
+++ b/vignettes/migration_with_demotools.Rmd
@@ -8,11 +8,10 @@ vignette: >
   %\VignetteIndexEntry{Migration with DemoTools}
   %\VignetteEngine{knitr::rmarkdown}
   %\VignetteEncoding{UTF-8}
-  %\VignetteDepends{tidyverse}
 header-includes:
 - \usepackage{amsmath}
 - \usepackage{amssymb}
----
+'---
 
 
 ```{r setup, include = FALSE}
@@ -70,7 +69,8 @@ The following is an example specifying values for each of the 13 possible parame
 
 ```{r}
 library(DemoTools)
-library(tidyverse)
+library(tibble)
+library(ggplot2)
 
 pars <- c(a1= 0.09, alpha1= 0.1, 
           a2= 0.2, alpha2= 0.1, mu2= 21, lambda2= 0.4, 


### PR DESCRIPTION
`devtools::check` passes locally but GH actions is currently broken in Windows. Have to look into this (but it was coming from before). 