### PR TITLE
Adds child/oldage adjustment for mig_beta

### DIFF
--- a/R/mig_beta.R
+++ b/R/mig_beta.R
@@ -8,6 +8,8 @@
 #' the cohort parallelogram assuming uniform distribution assuming it is all
 #' migration. It finalizes by summing the estimate by age groups across the entire
 #' intercensal period to have a total migration during the entire period.
+#' Alternatively, a child adjustemt can be made using either a child-woman ratio
+#' or a child constant ratio.
 #'
 #' @param c1 numeric vector. The first (left) census in single age groups
 #' @param c2 numeric vector. The second (right) census in single age groups
@@ -25,6 +27,12 @@
 #' @param sex character string, either `"male"`, `"female"`, or `"both"`
 #' @param midyear logical. `FALSE` means all Jan 1 dates between `date1` and `date2` are returned. `TRUE` means all July 1 intercensal dates are returned.
 #' @param verbose logical. Shall we send informative messages to the console?
+#' @param child_adjust The method with which to adjust the youngest age groups.
+#' If \code{"none"}, no adjustment is applied (default). If
+#' child-woman ratio (\code{"cwr""}) is chosen, the first cohorts reflecting the
+#' difference between \code{date2 - date1} are adjusted (plus age 0). If
+#' child constant ratio (\code{"constant"}) is chosen, the first 15 age groups
+#' are adjusted.
 #' @param ... optional arguments passed to \code{lt_single_qx}
 #' @export
 #'
@@ -36,7 +44,8 @@
 #' @examples
 #'
 #' \dontrun{
-#'   mig_beta(
+#'
+#' mig_beta(
 #'   location = "Russian Federation",
 #'   sex = "male",
 #'   c1 = pop1m_rus2002,
@@ -44,7 +53,8 @@
 #'   date1 = "2002-10-16",
 #'   date2 = "2010-10-25",
 #'   age1 = 0:100,
-#'   births = c(719511L, 760934L, 772973L, 749554L, 760831L, 828772L, 880543L, 905380L, 919639L)
+#'   births = c(719511L, 760934L, 772973L, 749554L, 760831L, 828772L, 880543L, 905380L, 919639L),
+#'   child_adjust
 #' )
 #' }
 mig_beta <- function(
@@ -59,13 +69,15 @@ mig_beta <- function(
                      age_lx = NULL,
                      dates_lx = NULL,
                      births = NULL,
+
                      years_births = NULL,
                      location = NULL,
                      sex = "both",
                      midyear = FALSE,
                      verbose = TRUE,
-                     ...
-                     ) {
+                     child_adjust = c("none", "cwr", "constant"),
+                     ...) {
+  child_adjust <- match.arg(child_adjust)
 
   # convert the dates into decimal numbers
   date1 <- dec.date(date1)
@@ -112,86 +124,64 @@ mig_beta <- function(
   # and the decum_resid on the values.
   mat_resid <-
     data.table::dcast(
-                  pop_jan1[, list(year, age, decum_resid)],
-                  age ~ year,
-                  value.var = "decum_resid"
-                )
+      pop_jan1[, list(year, age, decum_resid)],
+      age ~ year,
+      value.var = "decum_resid"
+    )
+
   # Sum over all ages to get a total decum_resid over all years for each age.
   mig <- stats::setNames(rowSums(mat_resid, na.rm = TRUE), mat_resid$age)
+
+  # Child adjustment
+  mig <-
+    switch(
+      child_adjust,
+      "none" = mig,
+      "cwr" = mig_beta_cwr(mig, c1, c2, date1, date2),
+      "constant" = mig_beta_constant_child(mig, c1, c2)
+    )
+
   mig
 }
 
 
 
-
-
-mig_beta_cwr <- function(mig, 
-                         c1_females, 
-                         c2_females, 
-                         date1, 
-                         date2, 
-                         maternal_window = 30, 
-                         maternal_min = 15){
+mig_beta_cwr <- function(mig,
+                         c1_females,
+                         c2_females,
+                         date1,
+                         date2,
+                         maternal_window = 30,
+                         maternal_min = 15) {
   age <- names2age(mig)
-  
+
   # conservative guess at how many child ages to cover:
   n_cohs <- as.integer(ceiling(date2) - floor(date1))
-  
+
   mig_out <- mig
-  for (i in 1:n_cohs){
+  for (i in 1:n_cohs) {
     # index maternal ages
-    a_min      <- i + maternal_min
-    a_max      <- min(i + maternal_min + maternal_window, 49)
-    mat_ind    <- a_min:a_max
-    cwr_i      <- (c1_females[i] / sum(c1_females[mat_ind]) + c2_females[i] / sum(c2_females[mat_ind])) / 2
+    a_min <- i + maternal_min
+    a_max <- min(i + maternal_min + maternal_window, 49)
+    mat_ind <- a_min:a_max
+    cwr_i <- (c1_females[i] / sum(c1_females[mat_ind]) + c2_females[i] / sum(c2_females[mat_ind])) / 2
     # proportional to maternal neg mig.
     mig_out[i] <- cwr_i * sum(mig[mat_ind])
   }
-  
+
   mig_out
 }
 
 # rough stb at constant child adjustment
-mig_beta_constant_child <- function(mig, c1, c2, ageMax = 14){
+mig_beta_constant_child <- function(mig, c1, c2, ageMax = 14) {
   age <- names2age(mig)
-  
+
   denom <- (c1 + c2) / 2
-  
+
   ind <- age <= ageMax
   mig_rate_const <- sum(mig[ind]) / sum(denom[ind])
-  
+
   mig[ind] <- denom[ind] * mig_rate_const
-  
+
   mig
 }
-
-
-# One more function for optional old age smoothing
-
-
-
-
-# TR: prep for constant child. Need denom for rates though,
-# but ideally without re-calculating an intermediate object
-# that was already needed. Maybe be we can get exposures
-# from RUP. Hmm.
-# mig_beta_constant_child <- function(mig, 
-#                                     c1,
-#                                     c2,
-#                                     date1, 
-#                                     date2, 
-#                                     maternal_window = 30, 
-#                                     maternal_min = 15){
-#   age <- names2age(mig)
-#   
-#   # conservative guess at how many child ages to cover:
-#   n_cohs  <- as.integer(ceiling(date2) - floor(date1))
-#   
-#   mig_out <- mig
-#   
-#   
-#   
-#   mig_out
-# }
-# 
-

--- a/man/mig_beta.Rd
+++ b/man/mig_beta.Rd
@@ -22,6 +22,7 @@ mig_beta(
   sex = "both",
   midyear = FALSE,
   verbose = TRUE,
+  child_adjust = c("none", "cwr", "constant"),
   ...
 )
 }
@@ -58,6 +59,13 @@ mig_beta(
 
 \item{verbose}{logical. Shall we send informative messages to the console?}
 
+\item{child_adjust}{The method with which to adjust the youngest age groups.
+If \code{"none"}, no adjustment is applied (default). If
+child-woman ratio (\code{"cwr""}) is chosen, the first cohorts reflecting the
+difference between \code{date2 - date1} are adjusted (plus age 0). If
+child constant ratio (\code{"constant"}) is chosen, the first 15 age groups
+are adjusted.}
+
 \item{...}{optional arguments passed to \code{lt_single_qx}}
 }
 \value{
@@ -71,11 +79,14 @@ Census - Estimate by age from projection. It then distributes the NCE over
 the cohort parallelogram assuming uniform distribution assuming it is all
 migration. It finalizes by summing the estimate by age groups across the entire
 intercensal period to have a total migration during the entire period.
+Alternatively, a child adjustemt can be made using either a child-woman ratio
+or a child constant ratio.
 }
 \examples{
 
 \dontrun{
-  mig_beta(
+
+mig_beta(
   location = "Russian Federation",
   sex = "male",
   c1 = pop1m_rus2002,
@@ -83,7 +94,8 @@ intercensal period to have a total migration during the entire period.
   date1 = "2002-10-16",
   date2 = "2010-10-25",
   age1 = 0:100,
-  births = c(719511L, 760934L, 772973L, 749554L, 760831L, 828772L, 880543L, 905380L, 919639L)
+  births = c(719511L, 760934L, 772973L, 749554L, 760831L, 828772L, 880543L, 905380L, 919639L),
+  child_adjust
 )
 }
 }

--- a/man/mig_beta.Rd
+++ b/man/mig_beta.Rd
@@ -23,6 +23,8 @@ mig_beta(
   midyear = FALSE,
   verbose = TRUE,
   child_adjust = c("none", "cwr", "constant"),
+  oldage_adjust = c("none", "beers", "mav"),
+  oldage_min = 65,
   ...
 )
 }
@@ -61,10 +63,19 @@ mig_beta(
 
 \item{child_adjust}{The method with which to adjust the youngest age groups.
 If \code{"none"}, no adjustment is applied (default). If
-child-woman ratio (\code{"cwr""}) is chosen, the first cohorts reflecting the
+child-woman ratio (\code{"cwr"}) is chosen, the first cohorts reflecting the
 difference between \code{date2 - date1} are adjusted (plus age 0). If
 child constant ratio (\code{"constant"}) is chosen, the first 15 age groups
 are adjusted.}
+
+\item{oldage_adjust}{The type of adjustment to apply to ages at and above
+\code{oldage_min}. \code{'beers'} applies a beers graduation method
+while \code{'mav'} applies a moving average with cascading on the tails.
+For more information see \code{?mav} and \code{?graduation_beers}.}
+
+\item{oldage_min}{The minimum age from which to apply \code{oldage_adjust}.
+By default, set to 65, so any adjustment from \code{oldage_adjust} will be
+applied for 65+.}
 
 \item{...}{optional arguments passed to \code{lt_single_qx}}
 }
@@ -79,8 +90,7 @@ Census - Estimate by age from projection. It then distributes the NCE over
 the cohort parallelogram assuming uniform distribution assuming it is all
 migration. It finalizes by summing the estimate by age groups across the entire
 intercensal period to have a total migration during the entire period.
-Alternatively, a child adjustemt can be made using either a child-woman ratio
-or a child constant ratio.
+Alternatively, a child adjustment and an old age adjustment can be applied.
 }
 \examples{
 
@@ -94,8 +104,7 @@ mig_beta(
   date1 = "2002-10-16",
   date2 = "2010-10-25",
   age1 = 0:100,
-  births = c(719511L, 760934L, 772973L, 749554L, 760831L, 828772L, 880543L, 905380L, 919639L),
-  child_adjust
+  births = c(719511L, 760934L, 772973L, 749554L, 760831L, 828772L, 880543L, 905380L, 919639L)
 )
 }
 }

--- a/tests/testthat/test-mig_beta.R
+++ b/tests/testthat/test-mig_beta.R
@@ -648,3 +648,68 @@ test_that("mig_beta throws download messages when verbose = TRUE and LocID used"
     fixed = TRUE
   )
 })
+
+
+test_that("mig_beta applies child_adjustment correctly", {
+  res_none <-
+    mig_beta(
+      location = "Russian Federation",
+      sex = "male",
+      c1 = pop1m_rus2002,
+      c2 = pop1m_rus2010,
+      date1 = "2002-10-16",
+      date2 = "2010-10-25",
+      age1 = 0:100,
+      births = births,
+      child_adjust = "none"
+    )
+
+
+  res_cwr <-
+    mig_beta(
+      location = "Russian Federation",
+      sex = "male",
+      c1 = pop1m_rus2002,
+      c2 = pop1m_rus2010,
+      date1 = "2002-10-16",
+      date2 = "2010-10-25",
+      age1 = 0:100,
+      births = births,
+      child_adjust = "cwr"
+    )
+
+
+  res_constant <-
+    mig_beta(
+      location = "Russian Federation",
+      sex = "male",
+      c1 = pop1m_rus2002,
+      c2 = pop1m_rus2010,
+      date1 = "2002-10-16",
+      date2 = "2010-10-25",
+      age1 = 0:100,
+      births = births,
+      child_adjust = "constant"
+    )
+
+  # Check we don't mess up the format of migs (length, type, etc..)
+  for (i in list(res_none, res_cwr, res_constant)) check_form(i)
+
+  # Since cwr and constant can change, we only test that they adjust a certain
+  # number of ages rather than test the exact equality of results.
+
+  # CWR:
+  # Why 8? Because date1 and date2 differ by 8 years, so only the first 8
+  # cohorts are adjusted (+ age 0, making it 9).
+  # Test that the first 9 are adjusted:
+  expect_true(all((res_none - res_cwr)[1:9] != 0))
+
+
+  # Constant:
+  # Why 15? Because it's a fixed argument in mig_adjust_constant set to 14
+  # plug age 0, making it 15.
+  # Testhat that the first 15 are adjusted.
+  expect_true(all((res_none - res_constant)[1:15] != 0))
+
+
+})

--- a/tests/testthat/test-mig_beta.R
+++ b/tests/testthat/test-mig_beta.R
@@ -1,6 +1,6 @@
 check_form <- function(x) {
   expect_is(x, "numeric")
-  expect_true(length(x) == 103)
+  expect_true(length(x) == 101)
   expect_true(all(!is.na(x)))
   expect_named(x)
 }
@@ -87,13 +87,13 @@ test_that("Births are pulled from post-processed WPP2019", {
       date2 = "2010-10-25",
       age1 = 0:100
     ))
-    
+
   expect_true(any(outp == "births not provided. Downloading births for Russian Federation (LocID = 643), gender: `male`, years: 2002, 2003, 2004, 2005, 2006, 2007, 2008, 2009, 2010" #nolintr
   ))
 })
 
 test_that("mig_beta works well with different time points", {
-  # 3) mortality (abridged, 2 and 3 time points) and fertility given: 
+  # 3) mortality (abridged, 2 and 3 time points) and fertility given:
   mortdate1 <- 2003
   mortdate2 <- 2006
   mortdate3 <- 2010
@@ -138,7 +138,7 @@ test_that("mig_beta works well with different time points", {
    lxMat = lxmat3,
    dates_lx = c(mortdate1,mortdate2,mortdate3),
    age_lx = age_lx,
-   births = c(719511L, 760934L, 772973L, 749554L, 
+   births = c(719511L, 760934L, 772973L, 749554L,
               760831L, 828772L, 880543L, 905380L, 919639L),
    years_births = 2002:2010)
 
@@ -153,7 +153,7 @@ test_that("mig_beta works well with different time points", {
    lxMat = lxmat3,
    dates_lx = c(mortdate1,mortdate2,mortdate3),
    age_lx = age_lx,
-   births = c(719511L, 760934L, 772973L, 749554L, 
+   births = c(719511L, 760934L, 772973L, 749554L,
               760831L, 828772L, 880543L, 905380L, 919639L,1e6),
    years_births = 2002:2011)
 
@@ -228,7 +228,7 @@ test_that("mig_beta fails when lxmat is not correct", {
       lxMat = lxmat[, 1, drop = FALSE],
       dates_lx = c(mortdate1,mortdate2,mortdate3),
       age_lx = age_lx,
-      births = c(719511L, 760934L, 772973L, 749554L, 
+      births = c(719511L, 760934L, 772973L, 749554L,
                  760831L, 828772L, 880543L, 905380L, 919639L),
       years_births = 2002:2010),
     regexp = "lxMat should have at least two or more dates as columns. lxMat contains only one column" #nolintr
@@ -594,7 +594,7 @@ test_that("mig_beta throws download messages when verbose = TRUE", {
 
 
 test_that("mig_beta throws download messages when verbose = TRUE and LocID used", {
-  
+
   # 1) lx is downloaded
   outp <- capture_output_lines(
     mig_beta(
@@ -611,7 +611,7 @@ test_that("mig_beta throws download messages when verbose = TRUE and LocID used"
       verbose = TRUE
     ))
   expect_true(any(outp == "lxMat not provided. Downloading lxMat for Russian Federation (LocID = 643), gender: `both`, for years between 2002.8 and 2010.8"))
-  
+
   # 2) births are downloaded
   outp <- capture_output_lines(
     mig_beta(
@@ -627,7 +627,7 @@ test_that("mig_beta throws download messages when verbose = TRUE and LocID used"
       verbose = TRUE
     ))
   expect_true(any(outp == "births not provided. Downloading births for Russian Federation (LocID = 643), gender: `both`, years: 2002, 2003, 2004, 2005, 2006, 2007, 2008, 2009, 2010"))
-  
+
   # 3) dates_lx or years_births are being assumed anything
   expect_output(
     mig_beta(
@@ -712,4 +712,105 @@ test_that("mig_beta applies child_adjustment correctly", {
   expect_true(all((res_none - res_constant)[1:15] != 0))
 
 
+})
+
+
+
+test_that("mig_beta applies oldage_adjustment correctly", {
+  res_none <-
+    mig_beta(
+      location = "Russian Federation",
+      sex = "male",
+      c1 = pop1m_rus2002,
+      c2 = pop1m_rus2010,
+      date1 = "2002-10-16",
+      date2 = "2010-10-25",
+      age1 = 0:100,
+      births = births,
+      olage_adjust = "none"
+    )
+
+  res_beers <-
+    mig_beta(
+      location = "Russian Federation",
+      sex = "male",
+      c1 = pop1m_rus2002,
+      c2 = pop1m_rus2010,
+      date1 = "2002-10-16",
+      date2 = "2010-10-25",
+      age1 = 0:100,
+      births = births,
+      oldage_adjust = "beers"
+    )
+
+
+  res_mav <-
+    mig_beta(
+      location = "Russian Federation",
+      sex = "male",
+      c1 = pop1m_rus2002,
+      c2 = pop1m_rus2010,
+      date1 = "2002-10-16",
+      date2 = "2010-10-25",
+      age1 = 0:100,
+      births = births,
+      oldage_adjust = "mav"
+    )
+
+  # Check we don't mess up the format of migs (length, type, etc..)
+  for (i in list(res_none, res_beers, res_mav)) check_form(i)
+
+  # beers:
+  # expect that the 65+ are different because they're adjusted
+  # Why 66? Because first age is 0 and total length is 101
+  expect_true(all((res_none - res_beers)[66:length(res_beers)] != 0))
+
+
+  # mav:
+  # expect that the 65+ are different because they're adjusted
+  # Why 66? Because first age is 0 and total length is 101
+  expect_true(all((res_none - res_mav)[66:length(res_mav)] != 0))
+
+
+  # Test that oldage_min controls the age from which to adjust
+  # old ages
+  res_beers <-
+    mig_beta(
+      location = "Russian Federation",
+      sex = "male",
+      c1 = pop1m_rus2002,
+      c2 = pop1m_rus2010,
+      date1 = "2002-10-16",
+      date2 = "2010-10-25",
+      age1 = 0:100,
+      births = births,
+      oldage_adjust = "beers",
+      oldage_min = 70
+    )
+
+
+  res_mav <-
+    mig_beta(
+      location = "Russian Federation",
+      sex = "male",
+      c1 = pop1m_rus2002,
+      c2 = pop1m_rus2010,
+      date1 = "2002-10-16",
+      date2 = "2010-10-25",
+      age1 = 0:100,
+      births = births,
+      oldage_adjust = "mav",
+      oldage_min = 70
+    )
+
+  # beers:
+  # expect that the 65+ are different because they're adjusted
+  # Why 71? Because first age is 0 and total length is 101
+  expect_true(all((res_none - res_beers)[71:length(res_beers)] != 0))
+
+
+  # mav:
+  # expect that the 65+ are different because they're adjusted
+  # Why 71? Because first age is 0 and total length is 101
+  expect_true(all((res_none - res_mav)[71:length(res_mav)] != 0))
 })


### PR DESCRIPTION
Summary:

Child adjust:
* Either CWR or constant
* Docs added for new arg + tests checking that sepcific young age groups are adjusted

Old age adjustment:
* Either beers or mav (mav with cascading)
* Only applied to ages at and above (new) argument oldage_min.
* Docs for both new arguments + briefly describe in description
* Tests for different methods + check that new oldage_min arg works

Let me know if you need me to change stuff. I'll commit here as needed. 
