### PR TITLE
Additional changes to mig_resid

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -31,6 +31,7 @@ Suggests:
     testthat (>= 2.1.0),
     knitr,
     rmarkdown,
+    markdown,
     DT,
     ggplot2
 RdMacros: Rdpack

--- a/R/interp_coh.R
+++ b/R/interp_coh.R
@@ -168,7 +168,7 @@ interp_coh <- function(
   year <- NULL
 
   # add "cumulative" residual to the RUP (pop_jan1_pre)
-  pop_jan1[, `:=`(pop_jan1 = pop_jan1_pre + resid * discount)]
+  pop_jan1[, `:=`(pop_jan1 = pop_jan1 + resid * discount)]
   pop_jan1 <- pop_jan1[!is.na(cohort)]
 
   # TR: to get residualmigbeta prelim result, one takes the cumulative
@@ -968,13 +968,12 @@ reshape_pxt <- function(
   pop_jan1_pre <- pop_jan1_pre[input, on = "cohort"]
 
   pop_jan1_pre[, `:=`(
-    pop_jan1_pre = pop * coh_lx,
+    pop_jan1 = pop * coh_lx,
     age = floor(year) - cohort,
     year = floor(year) + 1
   )]
 
   pop_jan1_pre[, `:=`(year = ifelse(year == max(year), year + f2 - 1, year))]
-
   # calculate the discrepancy (migration) -- to be disrtibuted uniformly in
   # cohorts
   resid <-
@@ -982,7 +981,7 @@ reshape_pxt <- function(
     .[year == max(year)] %>%
     .[pop_c2, on = "cohort"]
 
-  resid[, `:=`(resid = pop_c2_obs - pop_jan1_pre)]
+  resid[, `:=`(resid = pop_c2_obs - pop_jan1)]
   # Only used in the process for diagnostics
   # resid[, `:=`(rel_resid = resid / pop_c2_obs)]
   resid <- resid[, list(cohort, resid)]
@@ -1034,6 +1033,7 @@ rup <- function(
                verbose,
                ...
                ) {
+
   check_args(
     lxMat = lxMat,
     births = births,

--- a/R/mig_beta.R
+++ b/R/mig_beta.R
@@ -40,6 +40,10 @@
 #' \code{date1} is 2002, the first 8 cohorts are adjusted. Otherwise, the user
 #' can supply an integer.
 #'
+#' @param cwr_factor A numeric between 0 and 1 to which adjust the CWR method
+#' for the young ages from \code{child_adjust}. \strong{This is only used
+#' when \code{child_adjust} is \code{"cwr"}}.
+#'
 #' @param oldage_adjust The type of adjustment to apply to ages at and above
 #' \code{oldage_min}. \code{'beers'} applies a beers graduation method
 #' while \code{'mav'} applies a moving average with cascading on the tails.

--- a/R/mig_beta.R
+++ b/R/mig_beta.R
@@ -26,12 +26,19 @@
 #' @param sex character string, either `"male"`, `"female"`, or `"both"`
 #' @param midyear logical. `FALSE` means all Jan 1 dates between `date1` and `date2` are returned. `TRUE` means all July 1 intercensal dates are returned.
 #' @param verbose logical. Shall we send informative messages to the console?
+#'
 #' @param child_adjust The method with which to adjust the youngest age groups.
 #' If \code{"none"}, no adjustment is applied (default). If
 #' child-woman ratio (\code{"cwr"}) is chosen, the first cohorts reflecting the
 #' difference between \code{date2 - date1} are adjusted (plus age 0). If
 #' child constant ratio (\code{"constant"}) is chosen, the first 15 age groups
 #' are adjusted.
+#'
+#' @param childage_max The maximum age from which to apply \code{child_adjust}.
+#' By default, set to \code{NULL}, which gets translated into all the cohorts
+#' between \code{date2} and \code{date1}. If \code{date2} is 2010 and
+#' \code{date1} is 2002, the first 8 cohorts are adjusted. Otherwise, the user
+#' can supply an integer.
 #'
 #' @param oldage_adjust The type of adjustment to apply to ages at and above
 #' \code{oldage_min}. \code{'beers'} applies a beers graduation method
@@ -83,6 +90,7 @@ mig_beta <- function(
                      midyear = FALSE,
                      verbose = TRUE,
                      child_adjust = c("none", "cwr", "constant"),
+                     childage_max = NULL,
                      oldage_adjust = c("none", "beers", "mav"),
                      oldage_min = 65,
                      ...) {
@@ -92,6 +100,11 @@ mig_beta <- function(
   # convert the dates into decimal numbers
   date1 <- dec.date(date1)
   date2 <- dec.date(date2)
+
+  # If null, assume, the cohorts between censuses date2 and dates2
+  if (is.null(childage_max)) {
+    childage_max <- as.integer(ceiling(date2) - floor(date1))
+  }
 
   res_list <- rup(
     c1 = c1,
@@ -148,8 +161,8 @@ mig_beta <- function(
     switch(
       child_adjust,
       "none" = mig,
-      "cwr" = mig_beta_cwr(mig, c1, c2, date1, date2),
-      "constant" = mig_beta_constant_child(mig, c1, c2)
+      "cwr" = mig_beta_cwr(mig, c1, c2, date1, date2, n_cohs = childage_max),
+      "constant" = mig_beta_constant_child(mig, c1, c2, ageMax = childage_max)
     )
 
   # Old age adjustment
@@ -165,9 +178,7 @@ mig_beta <- function(
   ages_oldages <- as.integer(names(mig_oldage))
   mig[ages_oldages >= oldage_min] <- mig_oldage[ages_oldages >= oldage_min]
 
-  # Only keep ages 0-100 because otherwise beers (oldage_adjust) only returns
-  # ages until 100 making the return object inconsistent
-  mig[1:101]
+  mig
 }
 
 
@@ -177,11 +188,12 @@ mig_beta_cwr <- function(mig,
                          date1,
                          date2,
                          maternal_window = 30,
-                         maternal_min = 15) {
+                         maternal_min = 15,
+                         n_cohs = NULL) {
   age <- names2age(mig)
 
   # conservative guess at how many child ages to cover:
-  n_cohs <- as.integer(ceiling(date2) - floor(date1))
+  if (is.null(n_cohs)) n_cohs <- as.integer(ceiling(date2) - floor(date1))
 
   mig_out <- mig
   for (i in 1:n_cohs) {

--- a/R/mig_beta.R
+++ b/R/mig_beta.R
@@ -91,6 +91,7 @@ mig_beta <- function(
                      verbose = TRUE,
                      child_adjust = c("none", "cwr", "constant"),
                      childage_max = NULL,
+                     cwr_factor = 0.3,
                      oldage_adjust = c("none", "beers", "mav"),
                      oldage_min = 65,
                      ...) {
@@ -155,13 +156,12 @@ mig_beta <- function(
   # Sum over all ages to get a total decum_resid over all years for each age.
   mig <- stats::setNames(rowSums(mat_resid, na.rm = TRUE), mat_resid$age)
 
-
   # Child adjustment
   mig <-
     switch(
       child_adjust,
       "none" = mig,
-      "cwr" = mig_beta_cwr(mig, c1, c2, date1, date2, n_cohs = childage_max),
+      "cwr" = mig_beta_cwr(mig, c1, c2, date1, date2, n_cohs = childage_max, cwr_factor = cwr_factor),
       "constant" = mig_beta_constant_child(mig, c1, c2, ageMax = childage_max)
     )
 
@@ -189,7 +189,9 @@ mig_beta_cwr <- function(mig,
                          date2,
                          maternal_window = 30,
                          maternal_min = 15,
-                         n_cohs = NULL) {
+                         n_cohs = NULL,
+                         cwr_factor = 0.3) {
+
   age <- names2age(mig)
 
   # conservative guess at how many child ages to cover:
@@ -203,7 +205,7 @@ mig_beta_cwr <- function(mig,
     mat_ind <- a_min:a_max
     cwr_i <- (c1_females[i] / sum(c1_females[mat_ind]) + c2_females[i] / sum(c2_females[mat_ind])) / 2
     # proportional to maternal neg mig.
-    mig_out[i] <- cwr_i * sum(mig[mat_ind])
+    mig_out[i] <- cwr_factor * cwr_i * sum(mig[mat_ind])
   }
 
   mig_out

--- a/man/mig_beta.Rd
+++ b/man/mig_beta.Rd
@@ -24,6 +24,7 @@ mig_beta(
   verbose = TRUE,
   child_adjust = c("none", "cwr", "constant"),
   childage_max = NULL,
+  cwr_factor = 0.3,
   oldage_adjust = c("none", "beers", "mav"),
   oldage_min = 65,
   ...
@@ -74,6 +75,10 @@ By default, set to \code{NULL}, which gets translated into all the cohorts
 between \code{date2} and \code{date1}. If \code{date2} is 2010 and
 \code{date1} is 2002, the first 8 cohorts are adjusted. Otherwise, the user
 can supply an integer.}
+
+\item{cwr_factor}{A numeric between 0 and 1 to which adjust the CWR method
+for the young ages from \code{child_adjust}. \strong{This is only used
+when \code{child_adjust} is \code{"cwr"}}.}
 
 \item{oldage_adjust}{The type of adjustment to apply to ages at and above
 \code{oldage_min}. \code{'beers'} applies a beers graduation method

--- a/man/mig_beta.Rd
+++ b/man/mig_beta.Rd
@@ -23,6 +23,7 @@ mig_beta(
   midyear = FALSE,
   verbose = TRUE,
   child_adjust = c("none", "cwr", "constant"),
+  childage_max = NULL,
   oldage_adjust = c("none", "beers", "mav"),
   oldage_min = 65,
   ...
@@ -67,6 +68,12 @@ child-woman ratio (\code{"cwr"}) is chosen, the first cohorts reflecting the
 difference between \code{date2 - date1} are adjusted (plus age 0). If
 child constant ratio (\code{"constant"}) is chosen, the first 15 age groups
 are adjusted.}
+
+\item{childage_max}{The maximum age from which to apply \code{child_adjust}.
+By default, set to \code{NULL}, which gets translated into all the cohorts
+between \code{date2} and \code{date1}. If \code{date2} is 2010 and
+\code{date1} is 2002, the first 8 cohorts are adjusted. Otherwise, the user
+can supply an integer.}
 
 \item{oldage_adjust}{The type of adjustment to apply to ages at and above
 \code{oldage_min}. \code{'beers'} applies a beers graduation method

--- a/tests/testthat/test-mig_beta.R
+++ b/tests/testthat/test-mig_beta.R
@@ -678,6 +678,19 @@ test_that("mig_beta applies child_adjustment correctly", {
       child_adjust = "cwr"
     )
 
+  res_cwr_high <-
+    mig_beta(
+      location = "Russian Federation",
+      sex = "male",
+      c1 = pop1m_rus2002,
+      c2 = pop1m_rus2010,
+      date1 = "2002-10-16",
+      date2 = "2010-10-25",
+      age1 = 0:100,
+      births = births,
+      child_adjust = "cwr",
+      cwr_factor = 0.9
+    )
 
   res_constant <-
     mig_beta(
@@ -708,6 +721,11 @@ test_that("mig_beta applies child_adjustment correctly", {
   # Constant:
   # Testhat that the first 9 are adjusted.
   expect_true(all((res_none - res_constant)[1:9] != 0))
+
+
+  # Test that CWR with high cwr_factor returns higher younger ages than with 0.3,
+  # the default:
+  expect_true(all(res_cwr_high[1:9] > res_cwr[1:9]))
 
 })
 

--- a/tests/testthat/test-mig_beta.R
+++ b/tests/testthat/test-mig_beta.R
@@ -1,6 +1,6 @@
 check_form <- function(x) {
   expect_is(x, "numeric")
-  expect_true(length(x) == 101)
+  expect_true(length(x) == 103)
   expect_true(all(!is.na(x)))
   expect_named(x)
 }
@@ -699,18 +699,15 @@ test_that("mig_beta applies child_adjustment correctly", {
   # number of ages rather than test the exact equality of results.
 
   # CWR:
-  # Why 8? Because date1 and date2 differ by 8 years, so only the first 8
-  # cohorts are adjusted (+ age 0, making it 9).
+  # Why 9? Because date1 and date2 differ by 9 years, so only the first 9
+  # cohorts are adjusted.
   # Test that the first 9 are adjusted:
   expect_true(all((res_none - res_cwr)[1:9] != 0))
 
 
   # Constant:
-  # Why 15? Because it's a fixed argument in mig_adjust_constant set to 14
-  # plug age 0, making it 15.
-  # Testhat that the first 15 are adjusted.
-  expect_true(all((res_none - res_constant)[1:15] != 0))
-
+  # Testhat that the first 9 are adjusted.
+  expect_true(all((res_none - res_constant)[1:9] != 0))
 
 })
 
@@ -727,7 +724,7 @@ test_that("mig_beta applies oldage_adjustment correctly", {
       date2 = "2010-10-25",
       age1 = 0:100,
       births = births,
-      olage_adjust = "none"
+      oldage_adjust = "none"
     )
 
   res_beers <-
@@ -763,13 +760,13 @@ test_that("mig_beta applies oldage_adjustment correctly", {
   # beers:
   # expect that the 65+ are different because they're adjusted
   # Why 66? Because first age is 0 and total length is 101
-  expect_true(all((res_none - res_beers)[66:length(res_beers)] != 0))
+  expect_true(all((res_none - res_beers)[66:(length(res_beers) - 2)] != 0))
 
 
   # mav:
   # expect that the 65+ are different because they're adjusted
   # Why 66? Because first age is 0 and total length is 101
-  expect_true(all((res_none - res_mav)[66:length(res_mav)] != 0))
+  expect_true(all((res_none - res_mav)[66:(length(res_mav) - 2)] != 0))
 
 
   # Test that oldage_min controls the age from which to adjust
@@ -806,11 +803,11 @@ test_that("mig_beta applies oldage_adjustment correctly", {
   # beers:
   # expect that the 65+ are different because they're adjusted
   # Why 71? Because first age is 0 and total length is 101
-  expect_true(all((res_none - res_beers)[71:length(res_beers)] != 0))
+  expect_true(all((res_none - res_beers)[71:(length(res_beers) - 2)] != 0))
 
 
   # mav:
   # expect that the 65+ are different because they're adjusted
   # Why 71? Because first age is 0 and total length is 101
-  expect_true(all((res_none - res_mav)[71:length(res_mav)] != 0))
+  expect_true(all((res_none - res_mav)[71:(length(res_mav) - 2)] != 0))
 })


### PR DESCRIPTION
Don't accept this just yet. I'll add commits as I update stuff.

So far:
- [X] `mig_resid` now accepts `childage_max` as arg + docs updated and tests
- [X] partial fix to `mig_resid` subsetting final ages at the end (This needs further testing)
- [X] check() is failing, apparently because we need to add markdown as dependency now ([here](https://github.com/yihui/knitr/issues/1864))
- [ ] Peter's remarks