### PR TITLE
wrangling dimmension issue with interp

### DIFF
--- a/R/interp_lc_lim.R
+++ b/R/interp_lc_lim.R
@@ -287,13 +287,13 @@ interp_lc_lim <- function(input = NULL,
                         e0_Males), 
                   dates_e0,
                   dates_out,
-                  extrap = TRUE)[1, ]
+                  extrap = TRUE)
     
     e0f <- interp(rbind(e0_Females, 
                         e0_Females),
                   dates_e0,
                   dates_out,
-                  extrap = TRUE)[1, ]
+                  extrap = TRUE)
     
     # IW: issue with dimension in case the interpolation is for 1 date only
     if(ndates_out==1){

--- a/R/interp_lc_lim.R
+++ b/R/interp_lc_lim.R
@@ -295,6 +295,15 @@ interp_lc_lim <- function(input = NULL,
                   dates_out,
                   extrap = TRUE)[1, ]
     
+    # IW: issue with dimension in case the interpolation is for 1 date only
+    if(ndates_out==1){
+      e0m = e0m[1]
+      e0f = e0f[1]
+    }else{
+      e0m = e0m[1,]
+      e0f = e0f[1,]
+    }
+    
     # avoid divergence: same bx but not kt.
     if (prev_divergence){
       bxm <- bxf <- (bxm + bxf) * .5

--- a/R/lt_id.R
+++ b/R/lt_id.R
@@ -294,7 +294,7 @@ lt_id_Ll_S      <- function(nLx, lx = NULL, Age, AgeInt = NULL, N = 5) {
     radix <- ifelse(nLx[1]>1, 10^nchar(trunc(nLx[1])), 1)  
   }
   # validate nLx. Some zero in ages>100 could happen. YP should be non-zero in ages<80, even in historical pops (?)
-  stopifnot(all(nLx>=0, nLx[Age<80]>0, nLx[-n] < (radix*N)))
+  stopifnot(all(nLx>=0, nLx[Age<60]>0, nLx[-n] < (radix*N)))
   
   ## compute Sx (missing from the LTbr computation)
   # first age group is survival from births to the second age group


### PR DESCRIPTION
Catching `interp` results in case values for only one date is interpolated.
This should be fixed directly from `interp`, accepting not only matrixes but vectors, but in the meantime
