### PR TITLE
relax YP non-negative

### DIFF
--- a/R/lt_id.R
+++ b/R/lt_id.R
@@ -294,7 +294,9 @@ lt_id_Ll_S      <- function(nLx, lx = NULL, Age, AgeInt = NULL, N = 5) {
     radix <- ifelse(nLx[1]>1, 10^nchar(trunc(nLx[1])), 1)  
   }
   # validate nLx. Some zero in ages>100 could happen. YP should be non-zero in ages<80, even in historical pops (?)
-  stopifnot(all(nLx>=0, nLx[Age<60]>0, nLx[-n] < (radix*N)))
+  # IW: relax this condition on YP of non-negative YP because of huge heterogeneity on input lt
+  stopifnot(all(nLx>=0, # nLx[Age<60]>0, 
+                nLx[-n] < (radix*N)))
   
   ## compute Sx (missing from the LTbr computation)
   # first age group is survival from births to the second age group


### PR DESCRIPTION
I wonder if this can be relaxed for all ages, instead of continuing lowering the treshold age.
I think, for very rare/data-issue populations it´s prefereable an `NaN` on some some `Sx` when the ratio btw succesive `nLx` is `0/0`, or `Inf` if `1/0`, which don´t influence other lt functions, rather than `stop` the run.
Do you think is possible?
Thanks!
   