### PR TITLE
Documentation fix on mig_un_fam.R

### DIFF
--- a/R/mig_un_fam.R
+++ b/R/mig_un_fam.R
@@ -3,7 +3,7 @@
 #' calculate the net migration age schedule based on the Rogers and Castro formula for UN families.
 #' @param NM numeric. Total net migration to distribute between ages and sex.
 #' @param family character. Could be "Family", "Female Labor", "Male Labor".
-#' @param Single logical. Results by simple age. Default `FALSE`.
+#' @param Single logical. Results by simple age. Default `TRUE`.
 #' Typically from pre-working age and working age parts of in Roger-Castro formula.
 #' @param OAnew The age from which to group all ages into an open ended age group.
 #' By default it is set to 100, so it groups all ages up to 120, which is the


### PR DESCRIPTION
The documentation currently states that the default for `Single` is FALSE, but the code says it's TRUE. I've fixed the documentation.