### PR TITLE
Minimal reproducible example works!

### DIFF
--- a/R/lt_indirect.R
+++ b/R/lt_indirect.R
@@ -7,7 +7,7 @@
 #' @param age1 integer vector. Lower bound of age groups from first census. Last age is assumed OAG.
 #' @param age2 integer vector. Lower bound of age groups from second census. Last age is assumed OAG.
 #' @param sex character string. Either `"m"` for males, `"f"` for females (default). 
-#' @param mlt_family character string. Model life table family: `"Chilean"`, `"East"`, `"Far_East_Asian"`, `"General"`, `"Latin"`, `"North"`, `"South"`, `"South_Asian"` or `"West"` (default).
+#' @param mlt_family character string. Model life table family: `"CD_Chilean"`, `"CD_East"`, `"UN_Far_Eastern"`, `"UN_General"`, `"UN_Latin_American"`, `"CD_North"`, `"CD_South"`, `"UN_South_Asian"` or `"CD_West"` (default) and `"user"` - custom. In case if user method is selected the lifetable identical to the one provided by MortCast::MLTlookup should be provided by the `mlt_input_data` argument in the function body
 #' @param method character. Options include:
 #' * `"match"` use survival ratios for finding best mlt level (default).
 #' * `"bproj"` back-projection from second census (UN, 1983).
@@ -20,7 +20,9 @@
 #' @param q01_q05 numeric. Both values in case final life table be computed considering child mortality input values.
 #' @param span_pre_smooth numeric. smooth is applied to survival ratios by age in case is not null. Value is `span` parameter from `loess` function (between 0 and 1). Default `FALSE`.
 #' @param mlt_e0_logit_feeney numeric. Level as reference in `logit` and `feeney` methods.
-#' @param mlt_input_data data.frame. By default is used data from  \code{Morcast} package. But specific model can be included (be sure same columns are included with same names), ant that `mlt_family` be included as category in `type` column.
+#' @param mlt_input_data data.frame. By default is used data from  \code{Morcast} package. But specific model can be included (be sure same columns are included with same names), and that `mlt_family` be included as category in `type` column. 
+#' The corresponding column names are: `"type"` - character vector - the life table family type, `"sex"` - numeric vector - 1 for male and 2 for female,  `"age"` - numeric vector - age in 5 year intervals,  `"e0"` - numeric vector - life expectancy   
+#' `"mx"` - numeric vecrtor - mortality rates, `"lx"`, `"Lx"` and `"sx"` - corresponding life table columns
 #' @param extrapLaw character. Which mortality law is chosen for extension to 100 age in lt output. See `Demotools::lt_abridged` for mode details
 #' @param HIV_prev numeric. Estimates of population-based estimate of HIV prevalence by age. If some value is assigned, then will be assumed AIDS variation of the method based on Spectrum patterns.
 #' @param HIV_art numeric. Estimate of proportion using antiretroviral therapy (ART).
@@ -28,7 +30,13 @@
 #' \insertRef{preston2000demography}{DemoTools}
 #' @return A list with 45q15, 35q15, the life table as result of the method, the general implicit level, the age-specific implicit level, and nSx from input data.
 #' @export
-#' @importFrom data.table dplyr tidyr MortCast lubridate rms fertestr rms
+#' @importFrom data.table
+#' @importFrom dplyr lead mutate group_by bind_rows select summarise ungroup inner_join arrange distinct filter pull case_when
+#' @importFrom tidyr expand_grid
+#' @importFrom MortCast MLTlookup
+#' @importFrom lubridate decimal_date ymd
+#' @importFrom rms did not find any particular functions
+#' @importFrom fertestr logit ??????? Maybe it was accidentally added after?
 #' @examples1
 #' \dontrun{
 #' # PANAMA 1960-1970 from UN Manual X (Table 174). Get only level.
@@ -40,7 +48,7 @@
 #'     age1 = seq(0,75,5),
 #'     age2 = seq(0,75,5),
 #'     sex = "f",
-#'     mlt_family = "West",   NOT MATCHING
+#'     mlt_family = "West",
 #'     method = "match",
 #'     ages_fit = seq(0,75,5))$selected_level
 #' }
@@ -48,7 +56,11 @@
 # remove later. using them to not forget what packages were attached
 library(data.table)
 library(DemoTools)
-library(rms) # for predictNQX
+# library(rms) # for predictNQX
+library(tidyr)
+library(dplyr)
+library(lubridate)
+library(MortCast)
 # general function ---------------------------------------------------
 intercensal_survival <- function(c1,
                                  c2,
@@ -81,12 +93,17 @@ intercensal_survival <- function(c1,
       "UN_Far_Eastern",
       "UN_General",
       "UN_Latin_American",
-      "UN_South_Asian")
+      "UN_South_Asian",
+      "user")
+  
+  
   
   # which families consider
+  # I think this part should be replaced with stopifnot.
+  # matching does not work as intended
   if (!is.null(mlt_family)) {
     
-    mlt_family <- match.arg(mlt_family, mlt_families, several.ok = TRUE)
+    mlt_family <- match.arg(mlt_family, mlt_families, several.ok = FALSE) # was several.ok = FALSE
     
   } else {
     
@@ -115,12 +132,17 @@ intercensal_survival <- function(c1,
   
   # manage ages: fit to more wider group and minor OAG (open age group).
   # Always assumes that the last age is an OAG
-  
-  if(length(age1) != length(c1) | length(age2) != length(c2)) {
 
-    stop("The length of age and population vectors are different")
-    
-  }
+  # if(length(age1) != length(c1) | length(age2) != length(c2)) {
+  # 
+  #   stop("The length of age and population vectors are different")
+  # 
+  # }
+  
+  # now
+  stopifnot("Elements of your input vector do not have the same length!" =
+              length(age1) == length(c1) & length(age2) == length(c2)) # maybe & is better than OR
+  
   
   age1_int <- max(unique(diff(age1)))
   age2_int <- max(unique(diff(age2)))
@@ -131,17 +153,17 @@ intercensal_survival <- function(c1,
   
   # Same as the code below. Actually in our case these functions do nothing.
   # Is it because we have matching ages? 
-  c1 <- groupAges(c1, N = 1)
-  c2 <- groupAges(c2, N = 1)
+  # c1 <- groupAges(c1, N = age_int, OAnew = OAG) # are we sure we want this behavior?
+  # c2 <- groupAges(c2, N = age_int, OAnew = OAG)
   
-  # c1 <-   data.frame(c1 = c1,
-  #                    age1 = pmin(trunc(age1 / age_int) * age_int, OAG)) |>
-  #   aggregate(c1 ~ age1, sum) |>
-  #   subset(select = c1, drop = TRUE)
-  # c2 <-   data.frame(c2 = c2, 
-  #                    age2 = pmin(trunc(age2 / age_int) * age_int, OAG)) |>
-  #   aggregate(c2 ~ age2, sum) |> 
-  #   subset(select = c2, drop = TRUE)
+  c1 <-   data.frame(c1 = c1,
+                     age1 = pmin(trunc(age1 / age_int) * age_int, OAG)) |>
+    aggregate(c1 ~ age1, sum) |>
+    subset(select = c1, drop = TRUE)
+  c2 <-   data.frame(c2 = c2,
+                     age2 = pmin(trunc(age2 / age_int) * age_int, OAG)) |>
+    aggregate(c2 ~ age2, sum) |>
+    subset(select = c2, drop = TRUE)
   
   # Creates the fitting age vector that is important for some of the methods
   if(is.null(ages_fit)) {
@@ -155,13 +177,13 @@ intercensal_survival <- function(c1,
   # dec.date replaced with lubridate option
   if(!is.numeric(date1)) {
     
-    date1 <- round(lubridate::decimal_date(lubridate::ymd(date1)), digits = 2)
+    date1 <- round(decimal_date(ymd(date1)), digits = 2)
     
   }
   
   if(!is.numeric(date2)) {
     
-    date2 <- round(lubridate::decimal_date(lubridate::ymd(date2)), digits = 2)
+    date2 <- round(decimal_date(ymd(date2)), digits = 2)
     
   }
   
@@ -202,12 +224,12 @@ intercensal_survival <- function(c1,
   
   surv_data$c1_cum  <- lt_id_L_T(surv_data$c1)
   surv_data$c2_cum  <- lt_id_L_T(surv_data$c2)
-  surv_data$age_int <-  ifelse(age == OAG, NA, age_int)
+  surv_data$age_int <- ifelse(age == OAG, NA, age_int)
   
   # RT I can rewire this with no lead function using the bracket subseting but the readability will suffer
   surv_data$nSx     <- ifelse(surv_data$age < (OAG - interc_t), 
-                              dplyr::lead(surv_data$c2, interc_length) / c1,
-                              dplyr::lead(surv_data$c2_cum, interc_length) / surv_data$c1_cum)
+                              lead(surv_data$c2, interc_length) / c1,
+                              lead(surv_data$c2_cum, interc_length) / surv_data$c1_cum)
   surv_data$n       <- interc_t
   
   # RT It will look like this
@@ -226,7 +248,7 @@ intercensal_survival <- function(c1,
     message(
       paste0("Survival ratios exceeding 1 for the following age groups: ", paste(ages_nSx_greater1, collapse = ", "))) 
     
-    } 
+    }
   
   
   # pre-smooth on nSx with polynomial if span_pre_smooth is provided
@@ -242,7 +264,7 @@ intercensal_survival <- function(c1,
   # select input model family and standardize for same age_int, OAG and risk interval if defined by the user
   if(!is.null(mlt_input_data)) {
     
-    if(!all(colnames(mlt_input_data) %in% colnames(MortCast::MLTlookup))) {
+    if(!all(colnames(mlt_input_data) %in% colnames(MLTlookup))) {
       
       stop("Be sure to have your col names and model cathegories as in MortCast::MLTlookup")
       
@@ -259,7 +281,7 @@ intercensal_survival <- function(c1,
       
       this_sex <- ifelse(sex == "f", 2, 1)
       
-      mlt_this_family_all_ages <- MortCast::MLTlookup |> 
+      mlt_this_family_all_ages <- MLTlookup |> 
         subset(type %in% mlt_family, sex == this_sex)
       
       # e0 should be rounded to proximate available level
@@ -291,11 +313,11 @@ intercensal_survival <- function(c1,
         
         lt_abridged(lx  = lx_hiv_svd_comp_x[c(0, 1, seq(5, 100, 5)) + 1], 
                     Age = c(0, 1, seq(5, 100, 5))) |>
-          dplyr::mutate(type = "HIVSpectrum",
-                        sex  = ifelse(sex== "f", 2, 1)) |>
-          dplyr::group_by(type) |>
-          dplyr::mutate(e0 = ex[Age == 0])}) |>
-        dplyr::bind_rows() |>
+          mutate(type = "HIVSpectrum",
+                 sex  = ifelse(sex == "f", 2, 1)) |>
+          group_by(type) |>
+          mutate(e0 = ex[Age == 0])}) |>
+        bind_rows() |>
         dplyr::select(type, 
                       e0, 
                       sex, 
@@ -320,19 +342,19 @@ intercensal_survival <- function(c1,
   this_sex <-  ifelse(sex == "f", 2, 1)
   
   this_mlt_family <- mlt_this_family_all_ages |>
-    dplyr::mutate(age_desired = as.integer(pmin(trunc(age/age_int) * age_int, OAG))) |>
-    dplyr::group_by(type, e0, age_desired) |>
-    dplyr::summarise(mxn = sum(mx * Lx) / sum(Lx),
-                     lx  = max(lx),
-                     Lxn = sum(Lx), 
-                     .groups = 'drop') |>
-    dplyr::group_by(type, e0) |>
-    dplyr::mutate(Tx = lt_id_L_T(Lxn),
-                  ex = Tx / lx,
-                  nSx = ifelse(age_desired < (OAG - interc_t),
-                               dplyr::lead(Lxn, interc_length) / Lxn,
-                               dplyr::lead(Tx, interc_length)  / Tx),
-                  n = interc_t) |>
+    mutate(age_desired = as.integer(pmin(trunc(age/age_int) * age_int, OAG))) |>
+    group_by(type, e0, age_desired) |>
+    summarise(mxn = sum(mx * Lx) / sum(Lx),
+              lx  = max(lx),
+              Lxn = sum(Lx),
+              .groups = 'drop') |>
+    group_by(type, e0) |>
+    mutate(Tx  = lt_id_L_T(Lxn),
+           ex  = Tx / lx,
+           nSx = ifelse(age_desired < (OAG - interc_t),
+                        lead(Lxn, interc_length) / Lxn,
+                        lead(Tx, interc_length)  / Tx),
+           n   = interc_t) |>
     dplyr::select(type, 
                   e0, 
                   age = age_desired, 
@@ -343,7 +365,7 @@ intercensal_survival <- function(c1,
                   ex, 
                   nSx, 
                   n) |>
-    dplyr::ungroup()
+    ungroup()
   
   
   # Find best level for each nSx (Table 171, B.2 in MX)
@@ -356,15 +378,15 @@ intercensal_survival <- function(c1,
     mlt_data    <- this_mlt_family |> 
       subset(select = c(type, age, e0, nSx))
 
-    mlt_closest <- interp_level_mlt(obs_data, 
-                                    mlt_data, 
+    mlt_closest <- interp_level_mlt(obs_data = obs_data, 
+                                    mlt_data = mlt_data, 
                                     var_interp = "e0", 
                                     var_ref    = "nSx")
   }
   
   
   # variable-r method
-  if(method == "var-r"){
+  if(method == "var-r") {
     # get closest level for each nSx
     obs_data <- lt_ManualX_variable_r(age     = age, 
                                       Nx1     = pmax(c1_noadj, 1), # to avoid 0 pop in some age (age - specific rate goes Inf) 
@@ -377,8 +399,8 @@ intercensal_survival <- function(c1,
     mlt_data <- this_mlt_family |>
       subset(select = c(type, age, e0, ex))
     
-    mlt_closest <- interp_level_mlt(obs_data, 
-                                    mlt_data, 
+    mlt_closest <- interp_level_mlt(obs_data = obs_data, 
+                                    mlt_data = mlt_data, 
                                     var_interp = "e0", 
                                     var_ref    = "ex")
   }
@@ -390,30 +412,30 @@ intercensal_survival <- function(c1,
     surv_data_method <- data.frame(age = age, 
                                    c1  = c1, 
                                    c2  = c2) |>
-      dplyr::mutate(c1_cum = lt_id_L_T(c1), 
-                    c2_cum = lt_id_L_T(c2)) |>
-      dplyr::inner_join(this_mlt_family |>
-                          select(type, 
-                                 age, 
-                                 e0, 
-                                 nSx_mlt = nSx), 
-                        by = "age") |>
-      dplyr::arrange(type, e0, age) |>
-      dplyr::group_by(type, e0) |>
-      dplyr::mutate(c1_bproj = lead(c2, interc_length, default = NA) / nSx_mlt,
-                    c2_fproj = ifelse(age < OAG, 
-                                      lag(c1     * nSx_mlt, interc_length, default = NA),
-                                      lag(c1_cum * nSx_mlt, interc_length, default = NA)),
-                    c1_bproj_cum = ifelse(is.na(c1_bproj), NA, lt_id_L_T(c1_bproj)), # should work fine with no  na.omit(c1_bproj)
-                    c2_fproj_cum = ifelse(is.na(c2_fproj), NA, lt_id_L_T(c2_fproj))) |>
-      dplyr::ungroup()
+      mutate(c1_cum = lt_id_L_T(c1),
+             c2_cum = lt_id_L_T(c2)) |>
+      inner_join( dplyr::select(this_mlt_family,
+                                type,
+                                age,
+                                e0,
+                                nSx_mlt = nSx),
+                  by = "age") |>
+      arrange(type, e0, age) |>
+      group_by(type, e0) |>
+      mutate(c1_bproj = lead(c2, interc_length, default = NA) / nSx_mlt,
+             c2_fproj = ifelse(age < OAG,
+                               lag(c1     * nSx_mlt, interc_length, default = NA),
+                               lag(c1_cum * nSx_mlt, interc_length, default = NA)),
+             c1_bproj_cum = ifelse(is.na(c1_bproj), NA, lt_id_L_T(c1_bproj)), # should work fine with no  na.omit(c1_bproj)
+             c2_fproj_cum = ifelse(is.na(c2_fproj), NA, lt_id_L_T(c2_fproj))) |>
+      ungroup()
     
     # get best level for each direction
     if(method == "bproj") {
       
       obs_data <- surv_data_method |> 
         dplyr::select(age, c1_cum) |> 
-        dplyr::distinct()
+        distinct()
       
       mlt_data <- surv_data_method |> 
         dplyr::select(age, 
@@ -421,23 +443,29 @@ intercensal_survival <- function(c1,
                       e0, 
                       c1_cum = c1_bproj_cum)
       
-      mlt_closest <- interp_level_mlt(obs_data, mlt_data, "e0", "c1_cum")
-      
+      mlt_closest <- interp_level_mlt(obs_data   = obs_data, 
+                                      mlt_data   = mlt_data, 
+                                      var_interp = "e0", 
+                                      var_ref    = "c1_cum")
     }
     
     if(method == "fproj") {
       
       obs_data <- surv_data_method |> 
         dplyr::select(age, c2_cum) |> 
-        dplyr::distinct()
+        distinct()
+      
       mlt_data <- surv_data_method |> 
         dplyr::select(age, 
                       type, 
                       e0, 
                       c2_cum = c2_fproj_cum)
       
-      mlt_closest <- interp_level_mlt(obs_data, mlt_data, "e0", "c2_cum") |> 
-        dplyr::mutate(e0_interp = lead(e0_interp, interc_length))
+      mlt_closest <- interp_level_mlt(obs_data   = obs_data, 
+                                      mlt_data   = mlt_data, 
+                                      var_interp = "e0", 
+                                      var_ref    = "c2_cum") |> 
+        mutate(e0_interp = lead(e0_interp, interc_length))
       
     }
   }
@@ -463,11 +491,11 @@ intercensal_survival <- function(c1,
     if(!is.null(mlt_e0_logit_feeney)) {
       
       TOAGless5_l2.5 <-  mlt_this_family_all_ages |> 
-        dplyr::filter(e0 == trunc(mlt_e0_logit_feeney / 2.5) * 2.5) |>
-        dplyr::group_by(type) |>
-        dplyr::mutate(Tx = lt_id_L_T(Lx)) |>
-        dplyr::summarise(TOAGless5_l2.5 = sum(Tx[age == OAG - 5]) / sum(lx[age == 1] * 2.5 / 4 + lx[age == 5] * 1.5 / 4)) |>
-        dplyr::pull()
+        filter(e0 == trunc(mlt_e0_logit_feeney / 2.5) * 2.5) |>
+        group_by(type) |>
+        mutate(Tx = lt_id_L_T(Lx)) |>
+        summarise(TOAGless5_l2.5 = sum(Tx[age == OAG - 5]) / sum(lx[age == 1] * 2.5 / 4 + lx[age == 5] * 1.5 / 4)) |>
+        pull()
       
       mlt_data <- this_mlt_family %>%  
         dplyr::select(type, age, e0, ex)
@@ -475,11 +503,12 @@ intercensal_survival <- function(c1,
     } else {
       
       trunc_age <- OAG - 5
+      
       mlt_data  <- this_mlt_family |>
-        dplyr::filter(age < trunc_age) |> 
-        dplyr::group_by(type, e0) |>
-        dplyr::mutate(Tx      = lt_id_L_T(Lxn), 
-                      ex_temp = Tx / lx) |>
+        filter(age < trunc_age) |> 
+        group_by(type, e0) |>
+        mutate(Tx      = lt_id_L_T(Lxn),
+               ex_temp = Tx / lx) |>
         dplyr::select(type, age, e0, ex_temp)
       
       TOAGless5_l2.5 <- NULL
@@ -499,47 +528,47 @@ intercensal_survival <- function(c1,
     # interpolate
     obs_data <- surv_data_method_lx |> 
       dplyr::select(age, ex) %>% 
-      dplyr::filter(!is.na(ex))
+      filter(!is.na(ex))
     
-    mlt_closest <- interp_level_mlt(obs_data, mlt_data, "e0", "ex")
-    
+    mlt_closest <- interp_level_mlt(obs_data   = obs_data, 
+                                    mlt_data   = mlt_data, 
+                                    var_interp = "e0",
+                                    var_ref    = "ex")    
   }
   
   # given selected method, get best general level for all ages from tables
   mlt_level <- mlt_closest |>
-    dplyr::filter(age %in% ages_fit) |>
+    filter(age %in% ages_fit) |>
     # was series of ifelse
-    dplyr::mutate(e0_interp = dplyr::case_when(
+    mutate(e0_interp = case_when(
       e0_interp < e0_accept[1] ~ e0_accept[1],
       e0_interp > e0_accept[2] ~ e0_accept[2],
       TRUE                     ~ e0_interp)) |>
-    dplyr::group_by(type) |>
-    dplyr::summarise(ages_fitting = paste(range(ages_fit), collapse = "-"),
-                     mean_e0      = mean(    e0_interp, na.rm = TRUE),
-                     median_e0    = median(  e0_interp, na.rm = TRUE),
-                     coef_var     = sd(      e0_interp, na.rm = TRUE) / mean_e0,
-                     p25          = quantile(e0_interp, probs = .25, na.rm = TRUE),
-                     p75          = quantile(e0_interp, probs = .75, na.rm = TRUE))
+    group_by(type) |>
+    summarise(ages_fitting = paste(range(ages_fit), collapse = "-"),
+              mean_e0      = mean(    e0_interp, na.rm = TRUE),
+              median_e0    = median(  e0_interp, na.rm = TRUE),
+              coef_var     = sd(      e0_interp, na.rm = TRUE) / mean_e0,
+              p25          = quantile(e0_interp, probs = .25, na.rm = TRUE),
+              p75          = quantile(e0_interp, probs = .75, na.rm = TRUE))
   
   # get mlt best fit interpolating lx
   lx_mlt_level <- interp_level_mlt(
-    mlt_level |> 
-      dplyr::select(type, 
-                    e0 = median_e0) |> 
-      tidyr::expand_grid(age = c(0, 1, seq(5, 100, 5))),
-    mlt_this_family_all_ages |>
-      dplyr::filter(type %in% mlt_family, sex == this_sex) |>
+    obs_data = mlt_level |> 
+      dplyr::select(type, e0 = median_e0) |> 
+      expand_grid(age = c(0, 1, seq(5, 100, 5))), # expands generalized vector (data.frame) expand.grid cannot do it. Keep as is.
+    mlt_data = mlt_this_family_all_ages |>
+      filter(type %in% mlt_family, sex == this_sex) |>
       dplyr::select(type, age, e0, lx), 
-    "lx", "e0")
+    var_interp  = "lx", 
+    var_ref     = "e0")
   
   # logit method using match results
   if (method == "logit") {
     
     match_mlt_e0 <- mlt_level |> 
-      dplyr::mutate(mlt_e0 = round(median_e0 / 2.5) * 2.5)
+      mutate(mlt_e0 = round(median_e0 / 2.5) * 2.5)
     
-    
-    # here is one part with PURRR. Should we change it??
     lx_mlt_level <- lapply(mlt_family, function(X) { # Same here
       
       if (is.null(mlt_e0_logit_feeney) | is.HIV) {
@@ -556,7 +585,7 @@ intercensal_survival <- function(c1,
       
       this_mlt_family_X <-
         mlt_this_family_all_ages |> 
-        dplyr::filter(type == X, e0 == mlt_e0)
+        filter(type == X, e0 == mlt_e0)
       
       if (is.null(q01_q05)) {
         # message("logit 5p0 input is taken from match method level result")
@@ -571,20 +600,18 @@ intercensal_survival <- function(c1,
       }
       
       # apply method
-      e5_hat <-
-        (intercensal_surv_Preston_logit_var_r(
-          c1,
-          c2,
-          date1,
-          date2,
-          age,
-          age,
-          sex        = sex,
-          mlt_family = X,
-          mlt_e0     = mlt_e0,
-          ages_fit   = ages_fit,
-          q0_5       = q0_5
-        ))$e5
+      e5_hat <- (intercensal_surv_Preston_logit_var_r(
+        c1         = c1,
+        c2         = c2,
+        date1      = date1,
+        date2      = date2,
+        age1       = age, # is this correct????? NOT SURE
+        age2       = age, # SAME data here
+        sex        = sex,
+        mlt_family = X,
+        mlt_e0     = mlt_e0,
+        ages_fit   = ages_fit,
+        q0_5       = q0_5))$e5
       
       # limit range
       range_e5_family <- range(this_mlt_family$ex[this_mlt_family$age == 5])
@@ -601,36 +628,34 @@ intercensal_survival <- function(c1,
       }
       
       # interpolate considering age 1
-      lx_logit_rr <-
-        interp_level_mlt(
-          data.frame(age =  c(0, 1, seq(5, 100, 5)), e5 = e5_hat),
-          mlt_this_family_all_ages |>
-            dplyr::filter(type == X) |>
-            dplyr::group_by(type, e0) |>
-            dplyr::mutate(
-              Tx = lt_id_L_T(Lx),
-              ex = Tx / lx
-            ) |>
-            dplyr::mutate(e5 = ex[age == 5]) |>
-            dplyr::ungroup() |>
-            dplyr::select(type, age, e5, lx),
-          "lx",
-          "e5"
-        )
+      lx_logit_rr <- interp_level_mlt(
+        obs_data = data.frame(age =  c(0, 1, seq(5, 100, 5)), e5 = e5_hat),
+        mlt_data = mlt_this_family_all_ages |>
+          filter(type == X) |>
+          group_by(type, e0) |>
+          mutate(
+            Tx = lt_id_L_T(Lx),
+            ex = Tx / lx) |>
+          mutate(e5 = ex[age == 5]) |>
+          ungroup() |>
+          dplyr::select(type, age, e5, lx),
+        var_interp  = "lx",
+        var_ref = "e5")
+      
       lx_logit_rr$lx_interp <- pmax(lx_logit_rr$lx_interp, 0)
       
       return(lx_logit_rr)
       
     }
     ) |>
-      dplyr::bind_rows()
+      bind_rows()
   }
   
   # if both infant and child input are ok, impute first ages and recalculate lx
   if(length(q01_q05) == 2) {
     
     lx_mlt_level <- lx_mlt_level |>
-      dplyr::mutate(lx_interp = dplyr::case_when(
+      mutate(lx_interp = case_when(
         age == 1 ~ 1e5 * (1 - q01_q05[1]),
         age == 5 ~ 1e5 * (1 - q01_q05[2]),
         TRUE     ~ lx_interp))
@@ -640,37 +665,38 @@ intercensal_survival <- function(c1,
   # build lt with OAG from last fit age
   lt_selected <- lx_mlt_level |> 
     dplyr::select(type, age, lx_interp) |>
-    dplyr::filter(age <= 100)
+    filter(age <= 100)
   
   lt_selected <- split(x = lt_selected, lt_selected$type)
 
   result_list <- lapply(lt_selected, function(X) {
     
     X <- X[X$lx_interp > 0, ]
-    lt_abridged(lx = X$lx_interp, 
-                Age = X$age, 
-                Sex = sex, 
+    
+    lt_abridged(lx        = X$lx_interp, 
+                Age       = X$age, 
+                Sex       = sex, 
                 extrapLaw = extrapLaw) %>%
-      dplyr::mutate(type = unique(X$type), .before = 1) 
+      mutate(type = unique(X$type), .before = 1) 
 
   }) |>
-  
+    bind_rows() |>                  
+    group_by(type) |>
+    summarise(q15_45 = 1 - lx[Age == 60] / lx[Age == 15],
+              q15_35 = 1 - lx[Age == 50] / lx[Age == 15])
   
   # list of results to return
-  mlt_out <- list(Adult = lt_selected |>
-                    dplyr::group_by(type) |>
-                    dplyr::summarise(q15_45 = 1 - lx[Age == 60] / lx[Age == 15],
-                                     q15_35 = 1 - lx[Age == 50] / lx[Age == 15]),
+  mlt_out <- list(Adult = lt_selected,
                   lt_fit         = lt_selected,
                   selected_level = mlt_level,
                   rank_match     = mlt_closest,
                   surv_data      = surv_data)
   
-  if(!is.null(span_pre_smooth)) {
-    
-    mlt_out$plotplot_smooth_nSx <- plot(plot_smooth_nSx)
-    
-  }
+  # if(!is.null(span_pre_smooth)) {
+  #   
+  #   mlt_out$plotplot_smooth_nSx <- plot(plot_smooth_nSx)
+  #   
+  # }
   
   return(mlt_out)
   
@@ -685,7 +711,7 @@ intercensal_survival <- function(c1,
 #' @param age1 integer vector. Lower bound of age groups from first census. Last age is assumed OAG.
 #' @param age2 integer vector. Lower bound of age groups from second census. Last age is assumed OAG.
 #' @param sex character string. Either `"m"` for males, `"f"` for females (default). 
-#' @param mlt_family character string. Model life table family: `"Chilean"`, `"East"`, `"Far_East_Asian"`, `"General"`, `"Latin"`, `"North"`, `"South"`, `"South_Asian"` or `"West"` (default).
+#' @param mlt_family character string. Model life table family: `"CD_Chilean"`, `"CD_East"`, `"UN_Far_Eastern"`, `"UN_General"`, `"UN_Latin_American"`, `"CD_North"`, `"CD_South"`, `"UN_South_Asian"` or `"CD_West"` (default) and `"user"` - custom. In case if user method is selected the lifetable identical to the one provided by MortCast::MLTlookup should be provided by the `mlt_input_data` argument in the function body
 #' @param mlt_e0 numeric vector Level of life expectancy default is 60
 #' @param ages_fit integer vector. Ages to be considered when calculating the median of implied level by age. By default 10 to 70, but depends on data and method.  
 #' @param q0_5 numeric vector. q0_5 values probabilities of death
@@ -694,7 +720,11 @@ intercensal_survival <- function(c1,
 #' @references
 #' \insertRef{preston2000demography}{DemoTools}
 #' @return A list of 2: with e5 life expectancy values and model summary
-#' @importFrom dplyr tidyr MortCast lubridate
+#' @importFrom dplyr filter mutate group_by summarise ungroup select lag inner_join lead
+#' @importFrom tidyr
+#' @importFrom MortCast MLTlookup
+#' @importFrom lubridate decimal_date ymd
+#' 
 
 # Preston logit r ---------------------------------------------------------
 # based on Preston (2001, section 11.5.2)
@@ -712,44 +742,51 @@ intercensal_surv_Preston_logit_var_r <- function(c1,
                                                  verbose    = FALSE) {
   
   # manage ages: fit to more wider group
-  if(is.null(q0_5)) {
-    
-    stop("Please provide q0_5 values.")
-    
-  }
+  
+  
+  stopifnot("Please provide q0_5 values." =
+              is.null(q0_5)) # maybe & is better than OR
+  
+  # 
+  # if(is.null(q0_5)) {
+  #   
+  #   stop("Please provide q0_5 values.")
+  #   
+  # }
   
   age1_int <- max(unique(diff(age1)))
   age2_int <- max(unique(diff(age2)))
   age_int  <- max(age1_int, age2_int)  
-  
-  # identicall
-  c1 <- groupAges(c1, N = 1)
-  c2 <- groupAges(c2, N = 1)
-  
-  # c1       <- data.frame(c1   = c1,
-  #                        age1 = trunc(age1 / age_int) * age_int, OAG) |>
-  #   aggregate(c1 ~ age1, sum) |>
-  #   subset(select = c1, drop = TRUE)
-  # 
-  # 
-  # c2       <- data.frame(c2   = c2,
-  #                        age2 = trunc(age2 / age_int) * age_int, OAG) |>
-  #   aggregate(c2 ~ age2, sum) |>
-  #   subset(select = c2, drop = TRUE)
-  # 
   age      <- seq(0, min(max(age1), max(age2)), age_int)
   OAG      <- max(age)
   ages     <- length(age)
   
+  # identicall
+  # c1 <- groupAges(c1, N = age_int, OAnew = OAG) # not sure
+  # c2 <- groupAges(c2, N = age_int, OAnew = OAG)
+  
+  c1       <- data.frame(c1   = c1,
+                         age1 = trunc(age1 / age_int) * age_int, OAG) |>
+    aggregate(c1 ~ age1, sum) |>
+    subset(select = c1, drop = TRUE)
+
+
+  c2       <- data.frame(c2   = c2,
+                         age2 = trunc(age2 / age_int) * age_int, OAG) |>
+    aggregate(c2 ~ age2, sum) |>
+    subset(select = c2, drop = TRUE)
+  # 
+ 
+  
   if(!is.numeric(date1)) {
     
-    date1 <- round(lubridate::decimal_date(lubridate::ymd(date1)), digits = 2)
+    date1 <- round(decimal_date(ymd(date1)), digits = 2)
     
   }
   
   if(!is.numeric(date2)) {
     
-    date2 <- round(lubridate::decimal_date(lubridate::ymd(date2)), digits = 2)
+    date2 <- round(decimal_date(ymd(date2)), digits = 2)
     
   }
   # if((date2-date1)>15) message("more than 15 years in intercensal period")
@@ -761,13 +798,13 @@ intercensal_surv_Preston_logit_var_r <- function(c1,
   
   if(!is.numeric(date1)) {
     
-    date1 <- round(lubridate::decimal_date(lubridate::ymd(date1)), digits = 2)
+    date1 <- round(decimal_date(ymd(date1)), digits = 2)
     
   }
   
   if(!is.numeric(date2)) {
     
-    date2 <- round(lubridate::decimal_date(lubridate::ymd(date2)), digits = 2)
+    date2 <- round(decimal_date(ymd(date2)), digits = 2)
     
   }
   
@@ -783,43 +820,49 @@ intercensal_surv_Preston_logit_var_r <- function(c1,
   this_sex <- ifelse(sex == "f", 2, 1)
   
   
-  mlt_data <- MortCast::MLTlookup |>
-    dplyr::filter(type == mlt_family, 
+  mlt_data <- MLTlookup |>
+    filter(type == mlt_family, 
                   e0   == mlt_e0, 
                   sex  == this_sex) |>
-    dplyr::mutate(lx = lx,
-                  age_desired = as.integer(pmin(trunc(age / age_int) * age_int, OAG))) |>
-    dplyr::group_by(type, e0, age_desired) |> 
-    dplyr::summarise(mxn = sum(mx * Lx) / sum(Lx),
-                     lx  = max(lx),
-                     Lxn = sum(Lx), 
-                     .groups = 'drop') |>
-    dplyr::ungroup() |>
-    dplyr::group_by(type, e0) |>
-    dplyr::mutate(Tx = lt_id_L_T(Lxn),
+    mutate(lx          = lx,
+           age_desired = as.integer(pmin(trunc(age / age_int) * age_int, OAG))) |>
+    group_by(type, e0, age_desired) |>
+    summarise(mxn = sum(mx * Lx) / sum(Lx),
+              lx  = max(lx),
+              Lxn = sum(Lx)) |>
+    group_by(type, e0) |>
+    mutate(Tx = lt_id_L_T(Lxn),
                   ex = Tx / lx) |>
-    dplyr::select(type, e0, age = age_desired, mxn, lx, Lxn, Tx, ex) |>
-    dplyr::filter(age %in% age[age != OAG]) |>
-    dplyr::mutate(p5a = lx / lx[age == 5], q5a = 1 - p5a, `q5a/p5a`= q5a / p5a)
+    dplyr::select(type, 
+                  e0, 
+                  age = age_desired, 
+                  mxn, 
+                  lx, 
+                  Lxn, 
+                  Tx, 
+                  ex) |>
+    filter(age %in% age[age != OAG]) |>
+    mutate(p5a = lx / lx[age == 5], q5a = 1 - p5a, `q5a/p5a`= q5a / p5a)
   
   # surv data
   surv_data <- data.frame(age     = age, 
                           age_int = age_int, 
                           c1      = c1, 
                           c2      = c2) |>
-    dplyr::filter(age != OAG) |>
-    dplyr::mutate(r        = log(c2 / c1) / (date2 - date1),
-                  r_cum    =  rev(lt_id_L_T(rev(r))), # acumutlate forward
-                  r_cum    = dplyr::lag(r_cum, default = 0),
-                  c1.5     = (c2 - c1) / (r * interc_t),
-                  c_a      = (dplyr::lag(c1.5) + c1.5) / (interc_t * sum(c1.5)),
-                  r_cum_5  = r_cum * 5,
-                  ratio_rc = exp(-r_cum_5) * (1 - q0_5) / c_a)
+    filter(age != OAG) |>
+    mutate(r        = log(c2 / c1) / (date2 - date1),
+           r_cum    =  rev(lt_id_L_T(rev(r))), # acumutlate forward
+           r_cum    =  lag(r_cum, default = 0),
+           c1.5     = (c2 - c1) / (r * interc_t),
+           c_a      = (lag(c1.5) + c1.5) / (interc_t * sum(c1.5)),
+           r_cum_5  = r_cum * 5,
+           ratio_rc = exp(-r_cum_5) * (1 - q0_5) / c_a)
   
   # regression
-  regression_data <- dplyr::inner_join(surv_data, 
-                                       mlt_data, by = "age") |>
-    dplyr::filter(age >= 5)
+  regression_data <- inner_join(surv_data,
+                                mlt_data, 
+                                by = "age") |>
+    filter(age >= 5)
   
   model <- lm(ratio_rc ~ `q5a/p5a`, 
               data = regression_data, 
@@ -843,30 +886,30 @@ intercensal_surv_Preston_logit_var_r <- function(c1,
     
     if(verbose) {
       
-      message("Revise age fit selection. results were truncated for alpha on limits 0.1 or 3")
+      message("Revise age fit selection. Results were truncated for alpha on limits 0.1 or 3")
       
     }
   }
   
   regression_data <- regression_data |>
-    dplyr::mutate(p5a_hat = 1  /(1 + `q5a/p5a` * K), 
-                  nLx     = (p5a_hat + dplyr::lead(p5a_hat)) / 2 * 5)   
+    mutate(p5a_hat = 1  /(1 + `q5a/p5a` * K),
+           nLx     = (p5a_hat + lead(p5a_hat)) / 2 * 5)   
   
   # find ex for last age
   last_age          <- max(surv_data$age)
   obs_data_last_age <- data.frame(age        = last_age, 
                                   p5last_age = regression_data$p5a_hat[regression_data$age == last_age])
-  mlt_data_last_age <- MortCast::MLTlookup |> 
-    dplyr::filter(type == mlt_family, 
-                  sex  == this_sex) |> 
-    dplyr::group_by(type, e0) |>
-    dplyr::summarise(elast_age  = sum(Lx[age >= last_age]) / lx[age == last_age],
-                     p5last_age = lx[age == last_age] / lx[age == 5], .groups = 'drop') |>
-    dplyr::mutate(age = last_age) |>
+  mlt_data_last_age <- MLTlookup |> 
+    filter(type == mlt_family,
+           sex  == this_sex) |> 
+    group_by(type, e0) |>
+    summarise(elast_age  = sum(Lx[age >= last_age]) / lx[age == last_age],
+              p5last_age = lx[age == last_age] / lx[age == 5], .groups = 'drop') |>
+    mutate(age = last_age) |>
     dplyr::select(-e0)
   
-  mlt_closest <- interp_level_mlt(obs_data_last_age, 
-                                  mlt_data_last_age, 
+  mlt_closest <- interp_level_mlt(obs_data   = obs_data_last_age, 
+                                  mlt_data   = mlt_data_last_age, 
                                   var_interp = "elast_age", 
                                   var_ref    = "p5last_age")
   
@@ -880,10 +923,6 @@ intercensal_surv_Preston_logit_var_r <- function(c1,
   
 }
 
-
-
-
-
 #' Estimation of the besst mlt level from  survival ratios.
 #' @description 
 #' @param c1 numeric vector. Population counts in five-age groups, from first census with an exact reference date.
@@ -893,7 +932,8 @@ intercensal_surv_Preston_logit_var_r <- function(c1,
 #' @param var_interp character. variable to interpolate. defaults to e0
 #' @param var_ref cgaracter string. refference variable 
 #' @return A tibble with 1 row and 8 columns
-#' @importFrom dplyr tidyr
+#' @importFrom dplyr inner_join mutate arrange group_by slice select ungroup 
+#' @importFrom tidyr pivot_wider
 
 # level interpolation for any lt function ------------------------------------
 # TR: if this is just picking out two patterns for different e0 levels.
@@ -906,48 +946,52 @@ interp_level_mlt <- function(obs_data,
                              var_interp = "e0", 
                              var_ref    = "nSx") {
   
+  # replaced with stopifnot
+  stopifnot("Column names of the obs_data object do not match the names of the in mlt_data object." =
+              all(colnames(obs_data) %in% colnames(mlt_data)))
   # match var names
-  if(!all(colnames(obs_data) %in% colnames(mlt_data))) {
-    
-    stop("names in obs_data are not in mlt_data")
-    
-  }
+  # if(!all(colnames(obs_data) %in% colnames(mlt_data))) {
+  #   
+  #   stop("names in obs_data are not in mlt_data")
+  #   
+  # }
   
   match.arg(var_interp, colnames(mlt_data))
   
   # rename
-  var_reference_index_obs                     <- which(colnames(obs_data)==var_ref)
+  var_reference_index_obs                     <- which(colnames(obs_data) == var_ref)
   colnames(obs_data)[var_reference_index_obs] <- "ref"
-  var_reference_index_mlt                     <- which(colnames(mlt_data)==var_ref)
+  var_reference_index_mlt                     <- which(colnames(mlt_data) == var_ref)
   colnames(mlt_data)[var_reference_index_mlt] <- "var_ref"
-  var_interp_index_mlt                        <- which(colnames(mlt_data)==var_interp)
+  var_interp_index_mlt                        <- which(colnames(mlt_data) == var_interp)
   colnames(mlt_data)[var_interp_index_mlt]    <- "var_int"
   
   # join and find closest
-  data <- dplyr::inner_join(obs_data, mlt_data, 
-                            by = if(!"type" %in% colnames(obs_data)) {
-                              
-                              "age"
-                              
-                            } else { 
-                              
-                              c("type", "age")
-                              
-                            }) |>
-    dplyr::mutate(diff = abs(var_ref / ref - 1)) |>
-    dplyr::arrange(type, age, var_int) |>
-    dplyr::group_by(type, age) |>
-    dplyr::arrange(diff) |>
-    dplyr::slice(1:2) |>
-    dplyr::mutate(levels = c("left", "right")) |>
-    tidyr::pivot_wider(id_cols     = -diff, 
-                       names_from  = levels, 
-                       values_from = c(var_int, var_ref)) |>
-    dplyr::mutate(diff   = min(abs(ref - var_ref_left), abs(ref - var_ref_right)),
-                  interp = var_int_left + (ref - var_ref_left) / 
-                    (var_ref_right - var_ref_left) * (var_int_right - var_int_left)) |>
+  data <- inner_join(obs_data, 
+                     mlt_data,
+                     by = if(!"type" %in% colnames(obs_data)) {
+                       
+                       "age"
+                       
+                     } else {
+                       
+                       c("type", "age")
+                       
+                     }) |>
+    mutate(diff = abs(var_ref / ref - 1)) |>
+    arrange(type, age, var_int) |>
+    group_by(type, age) |>
+    arrange(diff) |>
+    slice(1:2) |>
+    mutate(levels = c("left", "right")) |>
+    pivot_wider(id_cols     = -diff,
+                names_from  = levels,
+                values_from = c(var_int, var_ref)) |>
+    mutate(diff   = min(abs(ref - var_ref_left), abs(ref - var_ref_right)),
+           interp = var_int_left + (ref - var_ref_left) /
+             (var_ref_right - var_ref_left) * (var_int_right - var_int_left)) |>
     dplyr::select(type, age, ref, var_ref_left, var_ref_right, var_int_left, var_int_right, interp) |>
-    dplyr::ungroup()
+    ungroup()
   
   # rename
   colnames(data) <- c("type", 
@@ -1061,7 +1105,8 @@ intercensal_surv_feeney <- function(c1,
 #' \insertRef{Preston & Benet, 1986}{DemoTools}
 #' @return A listdata.frame with age Nx1 Nx2 tx radix n_r_x nNx_mid n_before n_after N1_10_plus N2_10_plus N1_45_plus N2_45_plus nNx_mid_10plus nNx_mid_45plus r10plus Rx rho  Lx_star lx ndx Tx Sx ex
 #' @export
-#' @importFrom data.table lubridate
+#' @importFrom data.table
+#' @importFrom lubridate decimal_date ymd
 
 # variable r method --------------------------------------------------------------
 
@@ -1079,38 +1124,38 @@ intercensal_surv_var_r <- function(c1,
   age1_int <- max(unique(diff(age1)))
   age2_int <- max(unique(diff(age2)))
   age_int  <- max(age1_int, age2_int)  
-  
-  # TR: check for DemoTools function that does this: groupAges()
-  
-  c1 <- groupAges(c1, N = 1)
-  c2 <- groupAges(c2, N = 1)
-  
-  
-  # c1       <- data.frame(c1   = c1,
-  #                        age1 = trunc(age1 / age_int) * age_int, OAG) |>
-  #   aggregate(c1 ~ age1, sum) |>
-  #   subset(select = c1, drop = TRUE)
-  # 
-  # c2       <- data.frame(c2   = c2,
-  #                        age2 = trunc(age2 / age_int) * age_int, OAG) |>
-  #   aggregate(c2 ~ age2, sum) |>
-  #   subset(select = c2, drop = TRUE)
-  
   age      <- seq(0, min(max(age1), max(age2)), age_int)
   OAG      <- max(age)
   ages     <- length(age)
+  # TR: check for DemoTools function that does this: groupAges()
+  
+  # c1 <- groupAges(c1, N = age_int, OAnew = OAG)
+  # c2 <- groupAges(c2, N = age_int, OAnew = OAG)
+  
+  
+  c1       <- data.frame(c1   = c1,
+                         age1 = trunc(age1 / age_int) * age_int, OAG) |>
+    aggregate(c1 ~ age1, sum) |>
+    subset(select = c1, drop = TRUE)
+
+  c2       <- data.frame(c2   = c2,
+                         age2 = trunc(age2 / age_int) * age_int, OAG) |>
+    aggregate(c2 ~ age2, sum) |>
+    subset(select = c2, drop = TRUE)
+  
+
   
   # TR: lubridate seems lightweight, we might as well replace all instances of dec.date with the lubridate version
   # and deprecate our own version.
   
   if(!is.numeric(date1)) {
     
-    date1 <- round(lubridate::decimal_date(lubridate::ymd(date1)), digits = 2)
+    date1 <- round(decimal_date(ymd(date1)), digits = 2)
     
   }
   if(!is.numeric(date2)) {
     
-    date2 <- round(lubridate::decimal_date(lubridate::ymd(date2)), digits = 2)
+    date2 <- round(decimal_date(ymd(date2)), digits = 2)
     
   }
   
@@ -1143,7 +1188,8 @@ intercensal_surv_var_r <- function(c1,
 #' @author Michael Lachanski (mikelach@sas.upenn.edu)
 #' @return A data.frame with age Nx1 Nx2 tx radix n_r_x nNx_mid n_before n_after N1_10_plus N2_10_plus N1_45_plus N2_45_plus nNx_mid_10plus nNx_mid_45plus r10plus Rx rho  Lx_star lx ndx Tx Sx ex
 #' @export
-#' @importFrom data.table
+#' @importFrom data.table shift fifelse
+#' @importFrom tidyr replace_na %>%
 
 
 # TODO: make this legible, document, test.
@@ -1163,15 +1209,39 @@ lt_ManualX_variable_r <- function(age,
   
   # set rho parameters - taken from Table 185 on page 219 in Manual X.
   
-  if (max(age) >= 85)     { a = 0.006; b =  2.68;  c = 0.006 }
-  else if (max(age) >= 80){ a = 0.025; b =  4.30;  c = 0.029 }
-  else if (max(age) >= 75){ a = 0.053; b =  6.40;  c = 0.063 }
-  else if (max(age) >= 70){ a = 0.086; b =  8.77;  c = 0.102 }
-  else if (max(age) >= 65){ a = 0.119; b = 11.22;  c = 0.141 }
-  else if (max(age) >= 60){ a = 0.150; b = 13.66;  c = 0.176 }
-  else if (max(age) >= 55){ a = 0.179; b = 16.02;  c = 0.207 }
-  else if (max(age) >= 50){ a = 0.205; b = 18.28;  c = 0.235 }
-  else if (max(age)  < 50){ a = 0.229; b = 20.43;  c = 0.258 }
+  # not sure the lookup table looks better or reads better
+  # lookup_table <- data.frame(age1 = c(seq(85, 50, length.out = 8), 49.999),
+  #                            a   = c(0.006, 0.025, 0.053, 0.086, 0.119, 0.150, 0.179, 0.205, 0.229),
+  #                            b   = c(2.68,  4.30,  6.40,  8.77,  11.22, 13.66, 16.02, 18.28, 20.43),
+  #                            c   = c(0.006, 0.029, 0.063, 0.102, 0.141, 0.176, 0.207, 0.235, 0.258)) |>
+  #   subset(age1 >= max(age)) |>
+  #   tail(1)
+  # 
+  # a <- lookup_table$a
+  # b <- lookup_table$b
+  # c <- lookup_table$c
+  
+  # set rho parameters - taken from Table 185 on page 219 in Manual X.
+  if (max(age) >= 85)        { a = 0.006; b =  2.68;  c = 0.006
+  
+  } else if (max(age) >= 80) { a = 0.025; b =  4.30;  c = 0.029 
+  
+  } else if (max(age) >= 75) { a = 0.053; b =  6.40;  c = 0.063 
+  
+  } else if (max(age) >= 70) { a = 0.086; b =  8.77;  c = 0.102 
+  
+  } else if (max(age) >= 65) { a = 0.119; b = 11.22;  c = 0.141 
+  
+  } else if (max(age) >= 60) { a = 0.150; b = 13.66;  c = 0.176 
+  
+  } else if (max(age) >= 55) { a = 0.179; b = 16.02;  c = 0.207 
+  
+  } else if (max(age) >= 50) { a = 0.205; b = 18.28;  c = 0.235 
+  
+  } else if (max(age)  < 50) { a = 0.229; b = 20.43;  c = 0.258 
+  
+  }
+  
   
   DT_lt <- DT %>%
     # easier to just keep track of two n's follow Preston et al. (2001), p.186 - 187
@@ -1205,10 +1275,10 @@ lt_ManualX_variable_r <- function(age,
     
     DT_lt[nrow(DT),  n_r_x := NA_real_] %>%
       .[ ,
-         Rx := 0.5 * n_before * tidyr::replace_na(n_r_x, 0) + 
+         Rx := 0.5 * n_before * replace_na(n_r_x, 0) + 
            cumsum(shift(n_before, fill = 0) * shift(n_r_x, fill = 0))] %>%
       # only in Preston (1983) does he do this.
-      .[1, Rx :=NA_real_]
+      .[1, Rx := NA_real_]
   }
   
   DT_lt %>%
@@ -1232,7 +1302,7 @@ lt_ManualX_variable_r <- function(age,
     .[         , Sx := lx / lx[1]] %>%
     .[         , ex := Tx / lx]
   
-  if(full_lt == FALSE) { 
+  if(full_lt == FALSE) {
     
     DT_lt[age > 50 , ex := NA_real_] 
     
@@ -1251,7 +1321,7 @@ lt_ManualX_variable_r <- function(age,
   # indicators of the necessity of adjustment when errors in the growth rates arise
   # because of changes in enumeration completeness.
   
-  DT_lt[, ] # was DT_lt %>% `[`
+  # DT_lt[, ] # was DT_lt %>% `[`
   
   return(DT_lt)
   
@@ -1262,7 +1332,9 @@ cumSkipNA <- function(x, FUNC) {
   
   d            <- deparse(substitute(FUNC))
   funs         <- c("max", "min", "prod", "sum")
+  
   stopifnot(is.vector(x), is.numeric(x), d %in% funs)
+  
   FUNC         <- match.fun(paste0("cum", d))
   x[!is.na(x)] <- FUNC(x[!is.na(x)])
   
@@ -1287,6 +1359,8 @@ revcumsumSkipNA <- function(x) {
 #' @param art numeric vector. vector of ART values (%)
 #' @param adult numeric vector. "q45" or "q35" 
 #' @param im numeric vector. vector of 1q0 values
+#' @importFrom rms did not find any particular functions
+#' @importFrom fertestr logit?
 
 #' @references
 #' \insertRef{EXISTS}{DemoTools}
@@ -1399,7 +1473,7 @@ predictNQX <- function(sex,
   
 }
 
-#computes error estimates fro optimization in svd.comp model
+# computes error estimates fro optimization in svd.comp model
 # ALso from the same colleague for the calculation of his function. Just a helper really.
 
 error.svd <- function(weights, 
@@ -1438,7 +1512,7 @@ error.svd <- function(weights,
   
   # Splice in q0
   r.p[1,] <- q0.ref
-  r.p.exp <- expit(r.p)
+  r.p.exp <- exp(r.p) / (1 + exp(r.p)) # before was expit(r.p)
   
   # Predict q5
   q5.pred <- 1 - sapply(1 - r.p.exp[1:5, ,drop = FALSE], prod)


### PR DESCRIPTION
In this commit (not a complete list):
1) We have slightly adjusted the roxxygen documentation. In raticular the mlt_family argument, so that it match the values provided in the function. Also we added the description for mlt_input dataframe and adjusted the imports argument. 2) The possibility for using more than one family method was removed from the main function. 3) Where applicable the generic if statements were changed for stopifnot calls. 4) The groupAges functions were adjusted accordingly (BUT check issues below for some description). 5) All calls for the packages eg tidyr:: were removed  where unambiguety of the call is valid. 6) In all function calls the arguments were changed for unambiguety. 7) Some code was cleaned, bugs fixed and typos were fixed. 8) Some unit tests were performed.
9) The description for the custom mlt_input_data was added. Columns, structure and etc. What was attempted but not done:
1) The change of ifelse pipe to lookup table in lt_ManualX_variable_r. The lookuptable version is commented. I think that the if else version looks more obvious and feels better. 2) Rounding as of now is kept as is.Rounding in most parts is done to robustely match the arguments, but sometimes for the sake of reproducibility of the old results. We have to decide weather we really need to dive into the code to unambiguously decide for each case what is what. 3) Ivan suggests us to disregards the HIV functions for now. As it is yet to be decided weather we want them at all. Chances are very high. they might be completely removed from the code. Ivan promised to do the corresponding changes when the decision will be made. Issues:
I still am not completely sure aout the groupAges function. As of now, I keep the  original version and comment out the groupAges. We might like to check it during the call.